### PR TITLE
Checkstyle update

### DIFF
--- a/isyfact-masterpom/CHANGELOG.md
+++ b/isyfact-masterpom/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.7.0
+- `maven-checkstyle-plugin` auf Version `3.0.0` erhöht.
+
 # 1.6.0
 - `IFS-189`: Repositories der IsyFact-Standards zusammengeführt, Bibliotheken benutzen wieder gemeinsames Produkt-BOM und werden zentral über das POM isyfact-standards versioniert
 

--- a/isyfact-masterpom/pom.xml
+++ b/isyfact-masterpom/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>de.bund.bva.isyfact</groupId>
         <artifactId>isyfact-standards</artifactId>
-        <version>1.6.0</version>
+        <version>1.7.0</version>
     </parent>
 
     <properties>
@@ -455,7 +455,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.12</version>
+                <version>3.0.0</version>
                 <configuration>
                     <configLocation>${checkstyle.config}</configLocation>
                     <suppressionsLocation>${checkstyle.suppressions.config}</suppressionsLocation>


### PR DESCRIPTION
Version 2.12 nutzt die checkstyle version 5.7, die nicht die Syntax von Java8 unterstützt; es kommt zu parse Fehler bei Lambda etc.