### PR TITLE
maven-eclipse-plugin entfernt

### DIFF
--- a/isyfact-masterpom/CHANGELOG.md
+++ b/isyfact-masterpom/CHANGELOG.md
@@ -1,3 +1,6 @@
+# X.X.X
+- `eclipse-maven-plugin` gelöscht. Stattdessen sollte eclipse-m2e verwendet werden. 
+
 # 1.6.0
 - `IFS-189`: Repositories der IsyFact-Standards zusammengeführt, Bibliotheken benutzen wieder gemeinsames Produkt-BOM und werden zentral über das POM isyfact-standards versioniert
 

--- a/isyfact-masterpom/pom.xml
+++ b/isyfact-masterpom/pom.xml
@@ -405,42 +405,6 @@
                 <artifactId>maven-site-plugin</artifactId>
                 <version>3.5.1</version>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-eclipse-plugin</artifactId>
-                <version>2.10</version>
-                <configuration>
-                    <wtpversion combine.children="append">2.0</wtpversion>
-                    <downloadSources>true</downloadSources>
-                    <downloadJavadocs>true</downloadJavadocs>
-                    <additionalBuildcommands>
-                        <buildcommand>net.sf.eclipsecs.core.CheckstyleBuilder</buildcommand>
-                        <buildcommand>org.springframework.ide.eclipse.core.springbuilder</buildcommand>
-                    </additionalBuildcommands>
-                    <additionalProjectnatures>
-                        <projectnature>net.sf.eclipsecs.core.CheckstyleNature</projectnature>
-                        <projectnature>org.springframework.ide.eclipse.core.springnature</projectnature>
-                    </additionalProjectnatures>
-                    <additionalConfig>
-                        <file>
-                            <name>.checkstyle</name>
-                            <content><![CDATA[
-<?xml version="1.0" encoding="UTF-8"?>
-<fileset-config file-format-version="1.2.0" simple-config="true">
-    <fileset name="Alle" enabled="true" check-config-name="IsyFact-Checkstyle-Stil" local="false">
-        <file-match-pattern match-pattern="." include-pattern="true"/>
-    </fileset>
-    <filter name="FilesFromPackage" enabled="true">
-        <filter-data value="src/main/generated"/>
-        <filter-data value="src/test/java"/>
-    </filter>
-    <filter name="NonSrcDirs" enabled="true"/>
-</fileset-config>
-]]></content>
-                        </file>
-                    </additionalConfig>
-                </configuration>
-            </plugin>
        </plugins>
     </build>
 


### PR DESCRIPTION
"Note: This plugin is retired. It is no longer maintained.

Disclaimer: Users are advised to use m2e, the Eclipse Maven Integration instead of this plugin, as it can more closely resemble the actual build and runtime classpaths as described in the project pom.xml - among other advantages. However, there are project setups and workflows that still work more efficiently with statically generated Eclipse metadata - for example when there is a large number of projects in a reactor. That's where the Maven Eclipse Plugin can still help you."

Sollte ein Projekt "work more efficiently" hiermit, kann es das plugin selbst konfigurieren.