### PR TITLE
Plugin tidy-maven-plugin hinzufügen, dass sicherstellt, das POMs eine

### DIFF
--- a/isy-aufrufkontext/pom.xml
+++ b/isy-aufrufkontext/pom.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
-    <artifactId>isy-aufrufkontext</artifactId>
-    <packaging>jar</packaging>
-    <name>IsyFact-Aufrufkontext</name>
-    <description>Stellt eine Komponente zur Verwaltung des Aufrufkontextes bereit.</description>
 
     <parent>
         <groupId>de.bund.bva.isyfact</groupId>
         <artifactId>isyfact-standards</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>isy-aufrufkontext</artifactId>
+    <packaging>jar</packaging>
+
+    <name>IsyFact-Aufrufkontext</name>
+    <description>Stellt eine Komponente zur Verwaltung des Aufrufkontextes bereit.</description>
 
     <dependencyManagement>
         <dependencies>
@@ -32,7 +32,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>de.bund.bva.isyfact</groupId>

--- a/isy-batchrahmen/pom.xml
+++ b/isy-batchrahmen/pom.xml
@@ -1,16 +1,17 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
-    <artifactId>isy-batchrahmen</artifactId>
-    <packaging>jar</packaging>
-    <name>IsyFact-Batchrahmen</name>
 
     <parent>
         <groupId>de.bund.bva.isyfact</groupId>
         <artifactId>isyfact-standards</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>isy-batchrahmen</artifactId>
+    <packaging>jar</packaging>
+
+    <name>IsyFact-Batchrahmen</name>
 
     <dependencyManagement>
         <dependencies>
@@ -30,7 +31,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>de.bund.bva.isyfact</groupId>

--- a/isy-datetime/pom.xml
+++ b/isy-datetime/pom.xml
@@ -1,19 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
-    <artifactId>isy-datetime</artifactId>
-    <packaging>jar</packaging>
-
-    <name>IsyFact Datum &amp; Zeit</name>
 
     <parent>
         <groupId>de.bund.bva.isyfact</groupId>
         <artifactId>isyfact-standards</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>isy-datetime</artifactId>
+    <packaging>jar</packaging>
+
+    <name>IsyFact Datum &amp; Zeit</name>
 
     <dependencyManagement>
         <dependencies>
@@ -26,7 +24,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/isy-exception-core/pom.xml
+++ b/isy-exception-core/pom.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
-    <artifactId>isy-exception-core</artifactId>
-    <packaging>jar</packaging>
-    <name>IsyFact-Fehlerbehandlung (Basisklassen)</name>
-    <description>Stellt Basisklassen zur Fehlerbehandlung bereit.</description>
 
     <parent>
         <groupId>de.bund.bva.isyfact</groupId>
         <artifactId>isyfact-standards</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>isy-exception-core</artifactId>
+    <packaging>jar</packaging>
+
+    <name>IsyFact-Fehlerbehandlung (Basisklassen)</name>
+    <description>Stellt Basisklassen zur Fehlerbehandlung bereit.</description>
 
     <dependencyManagement>
         <dependencies>
@@ -25,7 +25,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/isy-exception-sst/pom.xml
+++ b/isy-exception-sst/pom.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
-    <artifactId>isy-exception-sst</artifactId>
-    <packaging>jar</packaging>
-    <name>IsyFact-Fehlerbehandlung (Schnittstelle)</name>
-    <description>Stellt die Schnittstelle der Komponente zur Fehlerbehandlung bereit.</description>
 
     <parent>
         <groupId>de.bund.bva.isyfact</groupId>
         <artifactId>isyfact-standards</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>isy-exception-sst</artifactId>
+    <packaging>jar</packaging>
+
+    <name>IsyFact-Fehlerbehandlung (Schnittstelle)</name>
+    <description>Stellt die Schnittstelle der Komponente zur Fehlerbehandlung bereit.</description>
 
     <dependencyManagement>
         <dependencies>
@@ -25,7 +25,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/isy-konfiguration/pom.xml
+++ b/isy-konfiguration/pom.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
-    <artifactId>isy-konfiguration</artifactId>
-    <packaging>jar</packaging>
-    <name>IsyFact-Konfiguration</name>
-    <description>Stellt eine Komponente für die Konfiguration von Anwendungen bereit.</description>
 
     <parent>
         <groupId>de.bund.bva.isyfact</groupId>
         <artifactId>isyfact-standards</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>isy-konfiguration</artifactId>
+    <packaging>jar</packaging>
+
+    <name>IsyFact-Konfiguration</name>
+    <description>Stellt eine Komponente für die Konfiguration von Anwendungen bereit.</description>
 
     <dependencyManagement>
         <dependencies>
@@ -32,7 +32,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>de.bund.bva.isyfact</groupId>

--- a/isy-logging/pom.xml
+++ b/isy-logging/pom.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
-    <artifactId>isy-logging</artifactId>
-    <packaging>jar</packaging>
-    <name>IsyFact-Logging</name>
-    <description>Stellt eine Komponente für das Logging bereit.</description>
 
     <parent>
         <groupId>de.bund.bva.isyfact</groupId>
         <artifactId>isyfact-standards</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>isy-logging</artifactId>
+    <packaging>jar</packaging>
+
+    <name>IsyFact-Logging</name>
+    <description>Stellt eine Komponente für das Logging bereit.</description>
 
     <dependencyManagement>
         <dependencies>
@@ -32,7 +32,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>de.bund.bva.isyfact</groupId>

--- a/isy-persistence/pom.xml
+++ b/isy-persistence/pom.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <name>IsyFact Persistence</name>
-
-    <artifactId>isy-persistence</artifactId>
-    <packaging>jar</packaging>
-    <description>Die Querschnittsbibliothek isy-persistence</description>
 
     <parent>
         <groupId>de.bund.bva.isyfact</groupId>
         <artifactId>isyfact-standards</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>isy-persistence</artifactId>
+    <packaging>jar</packaging>
+
+    <name>IsyFact Persistence</name>
+    <description>Die Querschnittsbibliothek isy-persistence</description>
 
     <dependencyManagement>
         <dependencies>
@@ -32,7 +32,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>de.bund.bva.isyfact</groupId>

--- a/isy-polling/pom.xml
+++ b/isy-polling/pom.xml
@@ -1,17 +1,17 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
-    <artifactId>isy-polling</artifactId>
-    <packaging>jar</packaging>
-
-    <name>IsyFact Polling</name>
 
     <parent>
         <groupId>de.bund.bva.isyfact</groupId>
         <artifactId>isyfact-standards</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>isy-polling</artifactId>
+    <packaging>jar</packaging>
+
+    <name>IsyFact Polling</name>
 
     <dependencyManagement>
         <dependencies>
@@ -31,29 +31,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.16</version>
-                <configuration>
-                    <argLine>-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9010
-                        -Dcom.sun.management.jmxremote.local.only=false
-                        -Dcom.sun.management.jmxremote.authenticate=false
-                        -Dcom.sun.management.jmxremote.ssl=false
-			-Dfile.encoding=${project.build.sourceEncoding}</argLine>
-                    <systemProperties>
-                        <user.language>de</user.language>
-                        <user.country>DE</user.country>
-                        <file.encoding>${project.build.sourceEncoding}</file.encoding>
-                    </systemProperties>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>de.bund.bva.isyfact</groupId>
@@ -108,4 +85,26 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.16</version>
+                <configuration>
+                    <argLine>-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9010
+                        -Dcom.sun.management.jmxremote.local.only=false
+                        -Dcom.sun.management.jmxremote.authenticate=false
+                        -Dcom.sun.management.jmxremote.ssl=false
+                        -Dfile.encoding=${project.build.sourceEncoding}</argLine>
+                    <systemProperties>
+                        <user.language>de</user.language>
+                        <user.country>DE</user.country>
+                        <file.encoding>${project.build.sourceEncoding}</file.encoding>
+                    </systemProperties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/isy-serviceapi-core/pom.xml
+++ b/isy-serviceapi-core/pom.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
-    <artifactId>isy-serviceapi-core</artifactId>
-    <name>IsyFact Service-API Anwendung</name>
 
     <parent>
         <groupId>de.bund.bva.isyfact</groupId>
         <artifactId>isyfact-standards</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>isy-serviceapi-core</artifactId>
+
+    <name>IsyFact Service-API Anwendung</name>
 
     <dependencyManagement>
         <dependencies>
@@ -30,7 +30,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>de.bund.bva.isyfact</groupId>

--- a/isy-serviceapi-sst/pom.xml
+++ b/isy-serviceapi-sst/pom.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
-    <artifactId>isy-serviceapi-sst</artifactId>
-    <name>IsyFact Service-API Transport-Objekte</name>
 
     <parent>
         <groupId>de.bund.bva.isyfact</groupId>
@@ -12,4 +8,7 @@
         <version>2.1.0-SNAPSHOT</version>
     </parent>
 
+    <artifactId>isy-serviceapi-sst</artifactId>
+
+    <name>IsyFact Service-API Transport-Objekte</name>
 </project>

--- a/isy-sicherheit/pom.xml
+++ b/isy-sicherheit/pom.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
-    <artifactId>isy-sicherheit</artifactId>
-    <packaging>jar</packaging>
-    <name>IsyFact-Sicherheit</name>
-    <description>Komponente für die Autorisierung von Benutzern in IsyFact-Anwendungen.</description>
 
     <parent>
         <groupId>de.bund.bva.isyfact</groupId>
         <artifactId>isyfact-standards</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>isy-sicherheit</artifactId>
+    <packaging>jar</packaging>
+
+    <name>IsyFact-Sicherheit</name>
+    <description>Komponente für die Autorisierung von Benutzern in IsyFact-Anwendungen.</description>
 
     <dependencyManagement>
         <dependencies>
@@ -32,7 +32,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>de.bund.bva.isyfact</groupId>

--- a/isy-sonderzeichen/pom.xml
+++ b/isy-sonderzeichen/pom.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
-    <artifactId>isy-sonderzeichen</artifactId>
-    <packaging>jar</packaging>
-    <name>IsyFact-Sonderzeichen</name>
-    <description>Komponente zur Unterstützung der Verarbeitung von Sonderzeichen.</description>
 
     <parent>
         <groupId>de.bund.bva.isyfact</groupId>
         <artifactId>isyfact-standards</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>isy-sonderzeichen</artifactId>
+    <packaging>jar</packaging>
+
+    <name>IsyFact-Sonderzeichen</name>
+    <description>Komponente zur Unterstützung der Verarbeitung von Sonderzeichen.</description>
 
     <dependencyManagement>
         <dependencies>
@@ -32,7 +32,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>de.bund.bva.isyfact</groupId>

--- a/isy-task/pom.xml
+++ b/isy-task/pom.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
-    <artifactId>isy-task</artifactId>
-    <name>IsyFact Task Scheduling</name>
 
     <parent>
         <groupId>de.bund.bva.isyfact</groupId>
         <artifactId>isyfact-standards</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>isy-task</artifactId>
+
+    <name>IsyFact Task Scheduling</name>
 
     <dependencyManagement>
         <dependencies>
@@ -31,7 +30,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>de.bund.bva.isyfact</groupId>

--- a/isy-ueberwachung/pom.xml
+++ b/isy-ueberwachung/pom.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
-    <artifactId>isy-ueberwachung</artifactId>
-    <packaging>jar</packaging>
-    <name>IsyFact-Überwachung</name>
 
     <parent>
         <groupId>de.bund.bva.isyfact</groupId>
         <artifactId>isyfact-standards</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>isy-ueberwachung</artifactId>
+    <packaging>jar</packaging>
+
+    <name>IsyFact-Überwachung</name>
 
     <dependencyManagement>
         <dependencies>
@@ -31,7 +31,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>de.bund.bva.isyfact</groupId>

--- a/isy-util/pom.xml
+++ b/isy-util/pom.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
-    <artifactId>isy-util</artifactId>
-    <packaging>jar</packaging>
-    <name>IsyFact-Utilities</name>
-    <description>Stellt Hilfsfunktionen für IsyFact-Anwendungen bereit.</description>
 
     <parent>
         <groupId>de.bund.bva.isyfact</groupId>
         <artifactId>isyfact-standards</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>isy-util</artifactId>
+    <packaging>jar</packaging>
+
+    <name>IsyFact-Utilities</name>
+    <description>Stellt Hilfsfunktionen für IsyFact-Anwendungen bereit.</description>
 
     <dependencyManagement>
         <dependencies>
@@ -32,7 +32,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>de.bund.bva.isyfact</groupId>

--- a/isyfact-products-bom/pom.xml
+++ b/isyfact-products-bom/pom.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
-    <artifactId>isyfact-products-bom</artifactId>
-    <packaging>pom</packaging>
-    <name>IsyFact Products BOM</name>
-    <description>Definiert die Versionen aller 3rd-Party Abhängigkeiten des Core Technology Stack der IsyFact.</description>
 
     <parent>
         <groupId>de.bund.bva.isyfact</groupId>
         <artifactId>isyfact-standards</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>isyfact-products-bom</artifactId>
+    <packaging>pom</packaging>
+
+    <name>IsyFact Products BOM</name>
+    <description>Definiert die Versionen aller 3rd-Party Abhängigkeiten des Core Technology Stack der IsyFact.</description>
 
     <properties>
         <spring.version>5.1.2.RELEASE</spring.version>

--- a/isyfact-standards-bom/pom.xml
+++ b/isyfact-standards-bom/pom.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
-    <artifactId>isyfact-standards-bom</artifactId>
-    <packaging>pom</packaging>
-    <name>IsyFact-Standards BOM</name>
-    <description>Definiert die Versionen aller Bibliotheken der IsyFact-Standards.</description>
 
     <parent>
         <groupId>de.bund.bva.isyfact</groupId>
         <artifactId>isyfact-standards</artifactId>
         <version>2.1.0-SNAPSHOT</version>
     </parent>
+
+    <artifactId>isyfact-standards-bom</artifactId>
+    <packaging>pom</packaging>
+
+    <name>IsyFact-Standards BOM</name>
+    <description>Definiert die Versionen aller Bibliotheken der IsyFact-Standards.</description>
 
     <!-- Dependency-Management für die Komponenten der IsyFact-Standards. -->
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- fooo-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>de.bund.bva.isyfact</groupId>
@@ -15,7 +15,6 @@
         Komponenten, die für die Entwicklung beliebiger Fachanwendungen relevant sind.
     </description>
     <url>http://isyfact.de</url>
-
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
@@ -31,12 +30,6 @@
             <organizationUrl>https://www.bva.bund.de</organizationUrl>
         </developer>
     </developers>
-
-    <scm>
-        <connection>scm:git:git://github.com/IsyFact/isyfact-standards.git</connection>
-        <developerConnection>scm:git:ssh://github.com:IsyFact/isyfact-standards.git</developerConnection>
-        <url>https://github.com/IsyFact/isyfact-standards</url>
-    </scm>
 
     <modules>
         <module>isyfact-standards-bom</module>
@@ -59,6 +52,12 @@
         <module>isy-sonderzeichen</module>
     </modules>
 
+    <scm>
+        <connection>scm:git:git://github.com/IsyFact/isyfact-standards.git</connection>
+        <developerConnection>scm:git:ssh://github.com:IsyFact/isyfact-standards.git</developerConnection>
+        <url>https://github.com/IsyFact/isyfact-standards</url>
+    </scm>
+
     <properties>
         <!-- Build-Variablen -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -69,14 +68,262 @@
         <enforced.maven.version>[3.1.1,4)</enforced.maven.version>
 
         <!-- Konfiguration des maven-surefire-plugin -->
-        <maven.surefire.argline>-Xmx1g -XX:MaxPermSize=256m -Dfile.encoding=${project.build.sourceEncoding}
-        </maven.surefire.argline>
+        <maven.surefire.argline>-Xmx1g -XX:MaxPermSize=256m -Dfile.encoding=${project.build.sourceEncoding}</maven.surefire.argline>
 
 
         <!-- Versionen von Plugins, die an mehreren Stellen genutzt werden -->
         <maven.enforcer.plugin.version>1.4.1</maven.enforcer.plugin.version>
         <maven.javadoc.plugin.version>2.10.4</maven.javadoc.plugin.version>
     </properties>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <resource>
+                <!-- Füge die Lizenzdateien dem JAR hinzu -->
+                <directory>license</directory>
+            </resource>
+        </resources>
+        <plugins>
+            <!-- Erlaube den Build nur mit richtiger Java & Maven Version -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>${maven.enforcer.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>${enforced.jdk.version}</version>
+                                </requireJavaVersion>
+                                <requireMavenVersion>
+                                    <version>${enforced.maven.version}</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>enforce-banned-dependencies</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <exclude>de.bund.bva.pliscommon:plis-*</exclude>
+                                        <exclude>log4j:log4j</exclude>
+                                    </excludes>
+                                    <message>Verbotene Abhängigkeiten gefunden, für die neuere Entsprechungen
+                                        (Group-ID: de.bund.bva.isyfact) existieren.
+                                        Bitte dependency:tree prüfen und entsprechend exkludieren.
+                                    </message>
+                                </bannedDependencies>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.0.1</version>
+                <configuration>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <source>${java.compile.version}</source>
+                    <target>${java.compile.version}</target>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven.javadoc.plugin.version}</version>
+                <configuration>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                    <charset>${project.build.sourceEncoding}</charset>
+                    <additionalparam>-Xdoclint:none</additionalparam>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.0.2</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.19.1</version>
+                <configuration>
+                    <!-- VM-Argumente für bspw. mehr Speicher bei grossen Testläufen -->
+                    <argLine>${maven.surefire.argline}</argLine>
+                    <systemPropertyVariables>
+                        <user.language>de</user.language>
+                        <user.country>DE</user.country>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.3</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>2.6</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.10</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <version>2.5.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-clean-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.7</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>javancss-maven-plugin</artifactId>
+                <version>2.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.7.1</version>
+            </plugin>
+            <!-- Sicherstellen, dass alle POMs Maven-Team-Standard konform sortiert sind. -->
+            <!-- Um eine POM korrekt zu sortieren, mvn tidy:pom ausführen. -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>tidy-maven-plugin</artifactId>
+                <version>1.1.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>3.0.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-report-plugin</artifactId>
+                <version>2.19.1</version>
+            </plugin>
+            <!-- Erzeugt einen Checkstyle-Bericht -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <configLocation>${checkstyle.config}</configLocation>
+                    <suppressionsLocation>${checkstyle.suppressions.config}</suppressionsLocation>
+                </configuration>
+            </plugin>
+            <!-- Erzeugt JavaDoc beim Build. Die Angabe des Encodings sorgt für eine korrekte Darstellung
+                von Sonderzeichen in den JavaDocs. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven.javadoc.plugin.version}</version>
+                <configuration>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                    <charset>${project.build.sourceEncoding}</charset>
+                    <additionalparam>-Xdoclint:none</additionalparam>
+                </configuration>
+            </plugin>
+            <!-- Das JXR-Plugin ermöglicht die Verlinkung von Source-Code in diversen Maven-Reports. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jxr-plugin</artifactId>
+                <version>2.5</version>
+            </plugin>
+            <!-- berichte über eingesetzte Bug Patterns. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>3.6</version>
+                <configuration>
+                    <sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
+                    <targetJdk>${java.compile.version}</targetJdk>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <version>3.0.4</version>
+            </plugin>
+        </plugins>
+    </reporting>
 
     <profiles>
         <!-- Profil um Snapshot-Versionen in Release-Tags zu verhindern -->
@@ -272,241 +519,4 @@
             </distributionManagement>
         </profile>
     </profiles>
-
-    <build>
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-            </resource>
-            <resource>
-                <!-- Füge die Lizenzdateien dem JAR hinzu -->
-                <directory>license</directory>
-            </resource>
-        </resources>
-
-        <plugins>
-            <!-- Erlaube den Build nur mit richtiger Java & Maven Version -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <version>${maven.enforcer.plugin.version}</version>
-                <executions>
-                    <execution>
-                        <id>enforce-maven</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <requireJavaVersion>
-                                    <version>${enforced.jdk.version}</version>
-                                </requireJavaVersion>
-                                <requireMavenVersion>
-                                    <version>${enforced.maven.version}</version>
-                                </requireMavenVersion>
-                            </rules>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>enforce-banned-dependencies</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <bannedDependencies>
-                                    <excludes>
-                                        <exclude>de.bund.bva.pliscommon:plis-*</exclude>
-                                        <exclude>log4j:log4j</exclude>
-                                    </excludes>
-                                    <message>Verbotene Abhängigkeiten gefunden, für die neuere Entsprechungen
-                                        (Group-ID: de.bund.bva.isyfact) existieren.
-                                        Bitte dependency:tree prüfen und entsprechend exkludieren.
-                                    </message>
-                                </bannedDependencies>
-                            </rules>
-                            <fail>true</fail>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>3.0.1</version>
-                <configuration>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
-                <configuration>
-                    <source>${java.compile.version}</source>
-                    <target>${java.compile.version}</target>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${maven.javadoc.plugin.version}</version>
-                <configuration>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                    <charset>${project.build.sourceEncoding}</charset>
-                    <additionalparam>-Xdoclint:none</additionalparam>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.0.2</version>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                        </manifest>
-                    </archive>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
-                <configuration>
-                    <!-- VM-Argumente für bspw. mehr Speicher bei grossen Testläufen -->
-                    <argLine>${maven.surefire.argline}</argLine>
-                    <systemPropertyVariables>
-                        <user.language>de</user.language>
-                        <user.country>DE</user.country>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>versions-maven-plugin</artifactId>
-                <version>2.3</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-war-plugin</artifactId>
-                <version>2.6</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.10</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-install-plugin</artifactId>
-                <version>2.5.2</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.8.2</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-clean-plugin</artifactId>
-                <version>3.0.0</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.7</version>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>javancss-maven-plugin</artifactId>
-                <version>2.0</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-site-plugin</artifactId>
-                <version>3.7.1</version>
-            </plugin>
-        </plugins>
-    </build>
-
-    <reporting>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>3.0.0</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>2.19.1</version>
-            </plugin>
-            <!-- Erzeugt einen Checkstyle-Bericht -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.0.0</version>
-                <configuration>
-                    <configLocation>${checkstyle.config}</configLocation>
-                    <suppressionsLocation>${checkstyle.suppressions.config}</suppressionsLocation>
-                </configuration>
-            </plugin>
-            <!-- Erzeugt JavaDoc beim Build. Die Angabe des Encodings sorgt für eine korrekte Darstellung
-                von Sonderzeichen in den JavaDocs. -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${maven.javadoc.plugin.version}</version>
-                <configuration>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                    <charset>${project.build.sourceEncoding}</charset>
-                    <additionalparam>-Xdoclint:none</additionalparam>
-                </configuration>
-            </plugin>
-            <!-- Das JXR-Plugin ermöglicht die Verlinkung von Source-Code in diversen Maven-Reports. -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jxr-plugin</artifactId>
-                <version>2.5</version>
-            </plugin>
-            <!-- berichte über eingesetzte Bug Patterns. -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.6</version>
-                <configuration>
-                    <sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
-                    <targetJdk>${java.compile.version}</targetJdk>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.4</version>
-            </plugin>
-        </plugins>
-    </reporting>
-
 </project>


### PR DESCRIPTION
konsistente Sortierung nach dem Maven-Team-Standard haben.