### PR TITLE
MessageSourceHolder: fix bug

### DIFF
--- a/isy-util/src/main/java/de/bund/bva/isyfact/util/spring/MessageSourceHolder.java
+++ b/isy-util/src/main/java/de/bund/bva/isyfact/util/spring/MessageSourceHolder.java
@@ -39,17 +39,6 @@ public final class MessageSourceHolder implements MessageSourceAware {
      * 
      * @param schluessel
      *            der Schlüssel des Resource-Bundles
-     * @return die Nachricht
-     */
-    public static String getMessage(String schluessel) {
-        return getMessage(schluessel, Locale.GERMANY, (String) null);
-    }
-
-    /**
-     * Liest eine Nachricht aus den in Spring konfigurierten Resource-Bundles aus.
-     * 
-     * @param schluessel
-     *            der Schlüssel des Resource-Bundles
      * @param parameter
      *            der Wert fuer die zu ersetzenden Platzhalter
      * @return die Nachricht


### PR DESCRIPTION
Die gelöschte Methode `getMessage` hat einen Bug, sie übergibt ein das gleiche wie `new String[] { null }`. Gewollt wird sein, `(String[]) null` oder `new String[] {}`.

Insgesamt ist die ganze Methode redundant, weil die gleiche Signatur schon von `public static String getMessage(String schluessel, String... parameter)` abgedeckt ist.