### PR TITLE
appender-entwicklung.xml Format verbessern

### DIFF
--- a/isy-logging/src/main/resources/resources/isylogging/logback/appender-entwicklung.xml
+++ b/isy-logging/src/main/resources/resources/isylogging/logback/appender-entwicklung.xml
@@ -25,7 +25,9 @@
 
         <!-- Encoder zum Steuern des Schreibens der Logeinträge -->
         <encoder>
-            <pattern>[P: %-5p] [T: %t] [L: %c] - [M: %m] %n</pattern>
+            <!-- Datum ist bei Tests idR. konstant. -->
+            <!-- package-Namen abkürzen. -->
+            <pattern>%date{HH:mm:ss.SSS} %-5level %logger{15} - %msg %n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
- Die Uhrzeit ist nützlich, um zu sehen wieviel Zeit in verschiedene Abschnitte gebraucht wird. Datum wird weggelassen, da das Logging in der Entwicklung idR nur über kurze Zeit geht.
- `[X: ...]` entfernt, das dies nur Noise ist.
- Thread entfernt, da ich bisher keinen Fall hatte, wo das nützlich war.
- `%logger{15}` Führt dazu, dass der Logger-package-Name abgekürzt wird. Da in unseren Anwendungen lange package-Namen verwendet werden, die sich großteils wiederholen, ist dies nützlich. Bsp: 

```
Alt:
[P: DEBUG] [T: main] [L: org.springframework.beans.factory.support.DefaultListableBeanFactory] - [M: Returning cached instance of singleton bean 'org.springframework.aop.support.DefaultBeanFactoryPointcutAdvisor#5'] 
Neu:
18:17:53.905 DEBUG o.s.b.f.s.DefaultListableBeanFactory - Returning cached instance of singleton bean 'org.springframework.aop.support.DefaultBeanFactoryPointcutAdvisor#5'

```