### PR TITLE
IFS-1960 Umsetzung Resource Owner Password Credentials Flow

### DIFF
--- a/isy-security/CHANGELOG.md
+++ b/isy-security/CHANGELOG.md
@@ -4,3 +4,4 @@
     - Property `isy.security.rolesClaimName` eingeführt
 - `IFS-2302`: Umsetzung des Mappings von Rollen auf Rechte
 - `IFS-2403`: Umstellung vorhandener Tests auf `isy-security-test`
+- `IFS-1960`: Bereitstellung einer Implementierung zur Authentifizierung mit Resource Owner Password Credentials

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/authentication/IsyOAuth2PasswordAuthenticationProvider.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/authentication/IsyOAuth2PasswordAuthenticationProvider.java
@@ -1,0 +1,97 @@
+package de.bund.bva.isyfact.security.authentication;
+
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.client.ClientAuthorizationException;
+import org.springframework.security.oauth2.client.OAuth2AuthorizationContext;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
+import org.springframework.security.oauth2.client.endpoint.DefaultPasswordTokenResponseClient;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient;
+import org.springframework.security.oauth2.client.endpoint.OAuth2PasswordGrantRequest;
+import org.springframework.security.oauth2.client.oidc.authentication.OidcIdTokenDecoderFactory;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoderFactory;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+
+/**
+ * Authentication Provider to obtain an {@link Authentication} with the OAuth2 Resource Owner Password Credentials flow.
+ */
+public class IsyOAuth2PasswordAuthenticationProvider implements AuthenticationProvider {
+
+    /** Repository containing the registered clients. */
+    private final ClientRegistrationRepository clientRegistrationRepository;
+
+    /** Converter to create a JwtAuthenticationToken from a JWT. */
+    private final JwtAuthenticationConverter jwtAuthenticationConverter;
+
+    /** AccessTokenResponseClient for the Password grant. */
+    private final OAuth2AccessTokenResponseClient<OAuth2PasswordGrantRequest> accessTokenResponseClient = new DefaultPasswordTokenResponseClient();
+
+    /** Factory for decoding and validating the returned JWT. */
+    private final JwtDecoderFactory<ClientRegistration> jwtDecoderFactory = new OidcIdTokenDecoderFactory();
+
+    public IsyOAuth2PasswordAuthenticationProvider(ClientRegistrationRepository clientRegistrationRepository,
+                                                   JwtAuthenticationConverter jwtAuthenticationConverter) {
+        this.clientRegistrationRepository = clientRegistrationRepository;
+        this.jwtAuthenticationConverter = jwtAuthenticationConverter;
+    }
+
+    public Authentication authenticate(String username, String password, String registrationId) throws AuthenticationException {
+        return authenticate(new IsyOAuth2PasswordAuthenticationToken(username, password, registrationId));
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        if (!(authentication instanceof IsyOAuth2PasswordAuthenticationToken)) {
+            return null;
+        }
+
+        IsyOAuth2PasswordAuthenticationToken passwordAuth = (IsyOAuth2PasswordAuthenticationToken) authentication;
+
+        String registrationId = passwordAuth.getRegistrationId();
+        ClientRegistration clientRegistration = clientRegistrationRepository.findByRegistrationId(registrationId);
+
+        OAuth2AccessToken accessToken = obtainAccessToken(clientRegistration, passwordAuth);
+        Jwt jwt = jwtDecoderFactory.createDecoder(clientRegistration).decode(accessToken.getTokenValue());
+
+        return jwtAuthenticationConverter.convert(jwt);
+    }
+
+    @Override
+    public boolean supports(Class authentication) {
+        return IsyOAuth2PasswordAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+
+    private OAuth2AccessToken obtainAccessToken(ClientRegistration clientRegistration, UsernamePasswordAuthenticationToken authentication) {
+        String username = authentication.getPrincipal().toString();
+        String password = authentication.getCredentials().toString();
+
+        OAuth2AuthorizationContext authorizationContext = OAuth2AuthorizationContext.withClientRegistration(clientRegistration)
+                .principal(authentication)
+                .attribute(OAuth2AuthorizationContext.USERNAME_ATTRIBUTE_NAME, username)
+                .attribute(OAuth2AuthorizationContext.PASSWORD_ATTRIBUTE_NAME, password)
+                .build();
+
+        OAuth2AuthorizedClientProvider clientProvider = OAuth2AuthorizedClientProviderBuilder.builder()
+                .password(passwordGrantBuilder -> passwordGrantBuilder.accessTokenResponseClient(accessTokenResponseClient))
+                .build();
+        OAuth2AuthorizedClient authorizedClient = clientProvider.authorize(authorizationContext);
+
+        if (authorizedClient == null) {
+            throw new ClientAuthorizationException(new OAuth2Error(OAuth2ErrorCodes.INVALID_GRANT), clientRegistration.getRegistrationId(),
+                    "clientRegistration.authorizationGrantType must be AuthorizationGrantType.PASSWORD");
+        }
+
+        return authorizedClient.getAccessToken();
+    }
+
+}

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/authentication/IsyOAuth2PasswordAuthenticationToken.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/authentication/IsyOAuth2PasswordAuthenticationToken.java
@@ -1,0 +1,19 @@
+package de.bund.bva.isyfact.security.authentication;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+public class IsyOAuth2PasswordAuthenticationToken extends UsernamePasswordAuthenticationToken {
+
+    /** Registration ID of the OAuth2 client to user for password grant authentication. */
+    private final String registrationId;
+
+    public IsyOAuth2PasswordAuthenticationToken(String username, String password, String registrationId) {
+        super(username, password);
+        this.registrationId = registrationId;
+    }
+
+    public String getRegistrationId() {
+        return registrationId;
+    }
+
+}

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/authentication/RolePrivilegeGrantedAuthoritiesConverter.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/authentication/RolePrivilegeGrantedAuthoritiesConverter.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 import org.springframework.core.convert.converter.Converter;

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/authentication/RolePrivilegeGrantedAuthoritiesConverter.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/authentication/RolePrivilegeGrantedAuthoritiesConverter.java
@@ -24,7 +24,7 @@ import de.bund.bva.isyfact.security.xmlparser.RolePrivilegesMapper;
 public class RolePrivilegeGrantedAuthoritiesConverter implements Converter<Jwt, Collection<GrantedAuthority>> {
 
     /** Logger. */
-    private static final IsyLogger LOG = IsyLoggerFactory.getLogger(RolePrivilegesMapper.class);
+    private static final IsyLogger LOG = IsyLoggerFactory.getLogger(RolePrivilegeGrantedAuthoritiesConverter.class);
 
     /** Authority prefix to use for all mapped authorities. */
     public static final String AUTHORITY_PREFIX = "PRIV_";

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/autoconfigure/IsySecurityAutoConfiguration.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/autoconfigure/IsySecurityAutoConfiguration.java
@@ -1,13 +1,17 @@
 package de.bund.bva.isyfact.security.autoconfigure;
 
+import org.springframework.boot.autoconfigure.security.oauth2.client.ClientsConfiguredCondition;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.core.GrantedAuthorityDefaults;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 
+import de.bund.bva.isyfact.security.authentication.IsyOAuth2PasswordAuthenticationProvider;
 import de.bund.bva.isyfact.security.authentication.RolePrivilegeGrantedAuthoritiesConverter;
 import de.bund.bva.isyfact.security.config.IsySecurityConfigurationProperties;
 import de.bund.bva.isyfact.security.xmlparser.RolePrivilegesMapper;
@@ -49,6 +53,13 @@ public class IsySecurityAutoConfiguration {
     @Bean
     public GrantedAuthorityDefaults grantedAuthorityDefaults() {
         return new GrantedAuthorityDefaults(RolePrivilegeGrantedAuthoritiesConverter.AUTHORITY_PREFIX);
+    }
+
+    @Bean
+    @Conditional(ClientsConfiguredCondition.class)
+    public IsyOAuth2PasswordAuthenticationProvider isyOAuth2PasswordAuthenticationProvider(
+            ClientRegistrationRepository clientRegistrationRepository) {
+        return new IsyOAuth2PasswordAuthenticationProvider(clientRegistrationRepository, jwtAuthenticationConverter());
     }
 
 }

--- a/isy-security/src/test/java/de/bund/bva/isyfact/security/authentication/IsyOAuth2PasswordAuthenticationProviderTest.java
+++ b/isy-security/src/test/java/de/bund/bva/isyfact/security/authentication/IsyOAuth2PasswordAuthenticationProviderTest.java
@@ -1,0 +1,90 @@
+package de.bund.bva.isyfact.security.authentication;
+
+import static de.bund.bva.isyfact.security.test.oidcprovider.EmbeddedOidcProviderStub.DEFAULT_ROLES_CLAIM_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.ClientAuthorizationException;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.oidc.StandardClaimNames;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+
+import de.bund.bva.isyfact.security.AbstractOidcProviderTest;
+import de.bund.bva.isyfact.security.example.IsySecurityTestApplication;
+
+@ActiveProfiles("test-clients")
+@SpringBootTest(classes = IsySecurityTestApplication.class)
+// clear context so WebClient will fetch a fresh access token
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class IsyOAuth2PasswordAuthenticationProviderTest extends AbstractOidcProviderTest {
+
+    @Autowired
+    private IsyOAuth2PasswordAuthenticationProvider passwordAuthenticationProvider;
+
+    @BeforeAll
+    public static void setup() {
+        // client with authorization-grant-type=password
+        embeddedOidcProvider.addUser("ressource-owner-password-credentials-test-client", "hypersecretpassword",
+                "admin", "admin123", Optional.empty(), Collections.singleton("Rolle_A"));
+        // client with authorization-grant-type=client_credentials
+        embeddedOidcProvider.addClient("client-credentials-test-client", "supersecretpassword", Collections.singleton("Rolle_A"));
+    }
+
+    @Test
+    public void shouldGetAuthTokenWithPasswordGrantClient() {
+        Authentication authentication = passwordAuthenticationProvider.authenticate("admin", "admin123", "ropc-client");
+
+        // security context is still empty
+        SecurityContext securityContext = SecurityContextHolder.getContext();
+        assertNull(securityContext.getAuthentication());
+
+        assertInstanceOf(JwtAuthenticationToken.class, authentication);
+        JwtAuthenticationToken jwtAuth = (JwtAuthenticationToken) authentication;
+        assertEquals("admin", jwtAuth.getTokenAttributes().get(StandardClaimNames.PREFERRED_USERNAME));
+        List<String> grantedAuthorityNames = jwtAuth.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.toList());
+        assertThat(grantedAuthorityNames).containsOnly("PRIV_Recht_A");
+        assertThat((List<String>) jwtAuth.getTokenAttributes().get(DEFAULT_ROLES_CLAIM_NAME)).containsOnly("Rolle_A");
+    }
+
+    @Test
+    public void shouldThrowAuthExceptionWithInvalidCredentials() {
+        assertThrows(ClientAuthorizationException.class,
+                () -> passwordAuthenticationProvider.authenticate("admin", "wrong", "ropc-client"));
+    }
+
+    @Test
+    public void shouldThrowErrorWithWrongClient() {
+        ClientAuthorizationException exception = assertThrows(ClientAuthorizationException.class,
+                () -> passwordAuthenticationProvider.authenticate("admin", "admin123", "testclient"));
+
+        assertEquals(OAuth2ErrorCodes.INVALID_GRANT, exception.getError().getErrorCode());
+        assertEquals("testclient", exception.getClientRegistrationId());
+    }
+
+    @Test
+    public void shouldReturnNullWhenPassingUnsupportedAuthentication() {
+        Authentication authRequest = new UsernamePasswordAuthenticationToken("admin", "admin123");
+        Authentication authentication = passwordAuthenticationProvider.authenticate(authRequest);
+
+        assertNull(authentication);
+    }
+
+}

--- a/isy-security/src/test/java/de/bund/bva/isyfact/security/example/config/OAuth2WebClientConfiguration.java
+++ b/isy-security/src/test/java/de/bund/bva/isyfact/security/example/config/OAuth2WebClientConfiguration.java
@@ -12,7 +12,8 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class OAuth2WebClientConfiguration {
 
     @Bean("testclient")
-    WebClient webClient(ClientRegistrationRepository clientRegistrationRepository, OAuth2AuthorizedClientService authorizedClientService) {
+    public WebClient webClient(ClientRegistrationRepository clientRegistrationRepository,
+                               OAuth2AuthorizedClientService authorizedClientService) {
         ServletOAuth2AuthorizedClientExchangeFilterFunction oauth = new ServletOAuth2AuthorizedClientExchangeFilterFunction(
                 new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService));
         oauth.setDefaultClientRegistrationId("testclient");

--- a/isy-security/src/test/resources/application-test-clients.yaml
+++ b/isy-security/src/test/resources/application-test-clients.yaml
@@ -14,3 +14,8 @@ spring:
             client-secret: supersecretpassword
             authorization-grant-type: client_credentials
             provider: testrealm
+          ropc-client:
+            client-id: ressource-owner-password-credentials-test-client
+            client-secret: hypersecretpassword
+            authorization-grant-type: password
+            provider: testrealm

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/changelog.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/changelog.adoc
@@ -11,5 +11,6 @@
 - `IFS-2403` Abschnitt zum OpenId Connect Provider Mock aus isy-security-test hinzugefügt
 - `IFS-1884` Umsetzung: Methodensicherheit
 - `IFS-1959` Abschnitt zum Auslesen des Behördenkennzeichens aus Security Context hinzugefügt
+- `IFS-1960` Kapitel zur Authentifizierung eines Clients mit Resource Owner Password Credentials hinzugefügt
 
 // end::release-3.0.0[]

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/inhalt.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/inhalt.adoc
@@ -4,17 +4,15 @@
 
 [[aufrufen_von_nachbarsystemen]]
 == Aufrufen von Nachbarsystemen
-Der Aufruf von Nachbarsystemen erfolgt auf Basis des reaktiven `Spring WebClient`. Um Nachbarsysteme aufzurufen, die auf Basis von `OAuth 2.0` abgesichert sind, ist grundlegend die Authentifizierung bei einem `Identitiy Provider` mit gültiger `client_id`, `client_secret` sowie `grant_type` erforderlich.
+
+Der Aufruf von Nachbarsystemen erfolgt auf Basis des reaktiven `Spring WebClient`.
+Um Nachbarsysteme aufzurufen, die auf Basis von `OAuth 2.0` abgesichert sind, ist grundlegend die Authentifizierung bei einem `Identitiy Provider` mit gültiger `client_id`, `client_secret` sowie `grant_type` erforderlich.
 Dieser liefert ein Bearer-Token zurück, in dem die Rollen und somit die Zugriffsmöglichkeiten der aufrufenden Anwendung definiert sind.
 
-[[authentifizierung_ccf]]
-=== Authentifizierung eines Clients mit Client Credentials
-Mit dem `OAuth 2.0`-Grant `client_credentials` steht eine vereinfachte Zugriffskontrolle für eine Client-Anwendung
-im Rahmen des `Client Credential Flow` zur Verfügung. Im Folgenden werden die notwendigen Schritte für die tokenbasierte Authentifizierung einer Anwendung als Client erläutert.
-[[maven-dependency]]
+[[maven-dependencies]]
+=== Maven Dependencies
 
-=== Maven Dependency
-Hierzu sind zunächst die folgenden Abhängigkeiten erforderlich:
+Für die Authentifizierung mit einem `OAuth 2.0`-Client sind die folgenden Abhängigkeiten erforderlich:
 
 [[listing-maven-dep-client-cred]]
 .Maven Dependencies für Client Credentials
@@ -39,12 +37,35 @@ Hierzu sind zunächst die folgenden Abhängigkeiten erforderlich:
 </dependency>
 ----
 
-=== Spring Konfiguration
-Spring Security bietet umfassenden Support für `OAuth 2.0` und unterstützt die Authentifizierung interner Systeme auf Basis des `Client Credential Flow`, wobei auf Spring interne Mechanismen zugegriffen wird.
+[[konfigurationsparameter]]
+=== Konfigurationsparameter
 
-Um clientseitig die automatische Konfiguration einer Anwendung zu ermöglichen, werden zunächst die oben aufgeführten Abhängigkeiten eingebunden.
-Um im Rahmen des Client Credential Flows HTTP-Anfragen an einen Ressourcenserver stellen zu können, ist zusätzlich die Konfiguration des reaktiven `WebClient` erforderlich.
-Hierzu wird die Standardimplementierung mit dem Zusatz eines OAuth2-Autorisierungsfilters verwendet:
+Für die korrekte Anbindung an den `Identity Provider` ist die Angabe einiger Konfigurationsparameter notwendig, welche in der Konfigurationsdatei der Anwendung eingetragen werden müssen.
+Das Präfix sämtlicher Konfigurationsparameter `spring.security.oauth2` wird zur Vereinfachung in der folgenden Liste weggelassen.
+
+[[table-parameter-client-cred]]
+.Konfigurationsparameter einer Client-Anwendung
+[cols="3m,2m,8",options="header"]
+|===
+|Parameter |Wertebereich |Beschreibung
+|client.registration._<registrationId>_.client-id |String |Identifier der Client-Applikation im Autorisierungsserver.
+|client.registration._<registrationId>_.client-secret |String |Secret, das nur der Anwendung und dem Autorisierungsserver bekannt ist.
+|client.registration._<registrationId>_.authorization-grant-type |String |Methode, durch welche die Anwendung ein Bearer-Token erhält. Abhängig von dem zu verwendenden Flow auf `client_credentials` (Client Credentials Flow) oder `password` (Resource Owner Password Credentials Flow) zu setzen.
+|client.registration._<registrationId>_.provider |String |(Optional) ID des zu verwendenden Client-Providers, falls diese nicht mit der Registration-ID übereinstimmt.
+|client.provider._<providerId>_.issuer-uri |String |Der OpenID Connect Issuer Identifier für die Konfiguration des Clients über den Discovery Endpoint, beispielsweise in der Form `http://<identity-provider>/auth/realms/<realm>`.
+|===
+
+[[authentifizierung_ccf]]
+=== Authentifizierung eines Clients mit Client Credentials
+
+Mit dem `OAuth 2.0`-Grant `client_credentials` steht eine vereinfachte Zugriffskontrolle für eine Client-Anwendung im Rahmen des `Client Credential Flow` zur Verfügung.
+
+Spring Security bietet umfassenden Support für `OAuth 2.0` und unterstützt die Authentifizierung interner Systeme auf Basis des `Client Credentials Flow`, wobei auf Spring interne Mechanismen zugegriffen wird.
+
+Um clientseitig die automatische Konfiguration einer Anwendung zu ermöglichen, werden zunächst die oben aufgeführten Abhängigkeiten eingebunden und eine Client-Registration für den `Client Credentials Flow` angelegt.
+Um im Rahmen des `Client Credentials Flows` HTTP-Anfragen an einen Ressourcenserver stellen zu können, ist zusätzlich die Konfiguration des reaktiven `WebClient` erforderlich.
+Hierzu wird die Standardimplementierung mit dem Zusatz eines OAuth2-Autorisierungsfilters verwendet.
+Die "registrationId" ist hierbei auf die ID der für den `Client Credentials Flow` konfigurierten Client-Registration zu setzen.
 
 [[listing-spring-webclient-example]]
 .Spring WebClient Beispiel
@@ -56,34 +77,16 @@ public class OAuth2WebClientConfiguration {
     @Bean("webclient")
     WebClient webClient(ClientRegistrationRepository clientRegistrationRepository,
         OAuth2AuthorizedClientService authorizedClientService) {
-        ServletOAuth2AuthorizedClientExchangeFilterFunction oauth2 =
+        ServletOAuth2AuthorizedClientExchangeFilterFunction oauth =
             new ServletOAuth2AuthorizedClientExchangeFilterFunction(
                 new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository,
                     authorizedClientService));
         oauth.setDefaultClientRegistrationId("registrationId");
-        return WebClient.builder().apply(oauth2.oauth2Configuration()).build();
+        return WebClient.builder().filter(oauth).build();
     }
 
 }
 ----
-
-[[konfigurationsparameter]]
-=== Konfigurationsparameter
-
-Für die korrekte Anbindung an den `Identity Provider` ist die Angabe einiger Konfigurationsparameter notwendig. Das Präfix sämtlicher Konfigurationsparameter `spring.security.oauth2` wird zur Vereinfachung in der Liste unten weggelassen.
-
-
-[[table-parameter-client-cred]]
-.Konfigurationsparameter einer Client-Anwendung
-[cols="3m,2m,2m,8",options="header"]
-|===
-|Parameter |Wertebereich |Default |Beschreibung
-|client.registration.registrationId |String |_keiner_ | Identifier der `ClientRegistration`
-|client.registration.registrationId.client-id |String |_keiner_ | Identifier der Client-Applikation im Autorisierungsserver
-|client.registration.registrationId.client-secret |String |_keiner_ | Secret, das nur der Anwendung und dem Autorisierungsserver bekannt ist
-|client.registration.registrationId.authorization-grant-type |String |_client_credentials_ | Methode, durch welche die Anwendung ein Bearer-Token erhält (hier _client_credentials_)
-|client.provider.registrationId.issuer-uri |String |_keiner_ |Auto-Konfiguration des Identity-Providers, beispielsweise in der Form "http://<identity-provider>/auth/realms/<realm>/.well-known/openid-configuration"
-|===
 
 [[absicherung_von_service_schnittstellen]]
 == Absicherung von Service-Schnittstellen


### PR DESCRIPTION
* feat: **IFS-1960** add support for the Resource Owner Password Credentials flow
* docs: **IFS-1960** rework section about oauth clients to mention configuration of the password grant
* chore: **IFS-1960** add changelog entries
* fix: **IFS-1960** uses correct class for logging