### PR TITLE
Migrationsleitfaden zur Umstellung von isy-task auf isy-security

### DIFF
--- a/isyfact-standards-doc/src/docs/antora/modules/changelog/pages/migrationsleitfaden.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/changelog/pages/migrationsleitfaden.adoc
@@ -63,7 +63,7 @@ isy.security.oauth2.client.registration.TestClient.password=TestPasswort
 isy.security.oauth2.client.registration.TestClient.bhknz=TestBHKNZ
 ----
 
-.Batch-Konfiguration nach Umstellung von technischem Nutzer auf Confidential Client
+.Batch-Konfiguration nach Umstellung von _technischem Nutzer_ auf _technischen Client_
 [source,properties]
 ----
 batch.oauth2ClientRegistrationId=TestClient
@@ -127,7 +127,7 @@ isy.security.oauth2.client.registration.TestClient.password=TestPasswort
 isy.security.oauth2.client.registration.TestClient.bhknz=TestBHKNZ
 ----
 
-.Properties nach Umstellung von technischem Nutzer auf Confidential Client
+.Properties nach Umstellung von _technischem Nutzer_ auf _technischen Client_
 [source,properties]
 ----
 isy.task.tasks.halloWeltTask.oauth2ClientRegistrationId=TestClient

--- a/isyfact-standards-doc/src/docs/antora/modules/changelog/pages/migrationsleitfaden.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/changelog/pages/migrationsleitfaden.adoc
@@ -77,9 +77,6 @@ spring.security.oauth2.client.registration.TestClient.authorization-grant-type=c
 spring.security.oauth2.client.registration.TestClient.provider=TestRealm
 ----
 
-[[kapitel-sicherheit]]
-=== Sicherheit
-
 [[kapitel-task-scheduler]]
 === Task Scheduler
 
@@ -163,6 +160,10 @@ Damit dennoch alte HTTP-Invoker Schnittstellen aufgerufen werden können (welche
 Weitere Informationen können unter
 xref:isy-serviceapi-core:nutzungsvorgaben/inhalt.adoc#kompatibilitaet_if1_2_3[Nutzungsvorgaben HTTP-Invoker] nachgelesen werden.
 ====
+
+[[kapitel-sicherheit]]
+=== Sicherheit
+
 
 [[kapitel-dokumentation]]
 == Dokumentation

--- a/isyfact-standards-doc/src/docs/antora/modules/changelog/pages/migrationsleitfaden.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/changelog/pages/migrationsleitfaden.adoc
@@ -83,8 +83,8 @@ spring.security.oauth2.client.registration.TestClient.provider=TestRealm
 [[kapitel-task-scheduler]]
 === Task Scheduler
 
-In IsyFact 3.0 wurden die Nutzungsvorgaben zur authentifizierung von Tasks aktualisiert, da der Task Scheduling Baustein auf `isy-security` umgestellt wurde.
-Statt Benutzer, Passwort und BHKNZ (siehe <<task-properties-isy-sicherheit>>) muss in den Task Properties nur noch eine `registration-id` konfiguriert werden (siehe <<task-properties-isy-security>>).
+In IsyFact 3.0 wurden mit der Umstellung auf `isy-security` die Nutzungsvorgaben zur xref:isy-task:nutzungsvorgaben/master.adoc#spring-konfiguration[Authentifizierung von Tasks] aktualisiert.
+Statt Benutzer, Passwort und BHKNZ (siehe <<task-properties-isy-sicherheit>>) muss in den Task Properties eine `registration-id` konfiguriert werden (siehe <<task-properties-isy-security>>).
 
 [[task-properties-isy-sicherheit]]
 .Properties mit isy-sicherheit in IsyFact 2

--- a/isyfact-standards-doc/src/docs/antora/modules/changelog/pages/migrationsleitfaden.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/changelog/pages/migrationsleitfaden.adoc
@@ -47,7 +47,7 @@ Für die Batch-Konfiguration ist nicht relevant, ob die ClientRegistration den R
 .Batch-Konfiguration mit technischen Nutzer
 [source,properties]
 ----
-batch.registrationId=TestClient
+batch.oauth2ClientRegistrationId=TestClient
 
 # [...]
 
@@ -84,7 +84,7 @@ spring.security.oauth2.client.registration.TestClient.provider=TestRealm
 === Task Scheduler
 
 In IsyFact 3.0 wurden mit der Umstellung auf `isy-security` die Nutzungsvorgaben zur xref:isy-task:nutzungsvorgaben/master.adoc#spring-konfiguration[Authentifizierung von Tasks] aktualisiert.
-Statt Benutzer, Passwort und BHKNZ (siehe <<task-properties-isy-sicherheit>>) muss in den Task Properties eine `registration-id` konfiguriert werden (siehe <<task-properties-isy-security>>).
+Statt Benutzer, Passwort und BHKNZ (siehe <<task-properties-isy-sicherheit>>) muss in den Task Properties eine `oauth2ClientRegistrationId` konfiguriert werden (siehe <<task-properties-isy-security>>).
 
 [[task-properties-isy-sicherheit]]
 .Properties mit isy-sicherheit in IsyFact 2
@@ -101,19 +101,19 @@ isy.task.tasks.halloWeltTask.bhkz=TestBHKNZ
 .Properties mit isy-security in IsyFact 3
 [source,properties]
 ----
-isy.task.tasks.halloWeltTask.registration-id=TestClient
+isy.task.tasks.halloWeltTask.oauth2ClientRegistrationId=TestClient
 
 # [...]
 ----
 
 Eine entsprechende Spring Security ClientRegistration wird durch `isy-security` xref:isy-security:nutzungsvorgaben/master.adoc#konfigurationsparameter[ Konfigurationsparameter] bereitgestellt.
 Die folgenden Beispiele zeigen wie Konfigurationen nach der Migration aussehen können.
-Für die Task Scheduler konfiguration ist nicht relevant, ob die ClientRegistration den Resource-Owner-Password-Credentials Flow (`authorization-grant-type: password`) oder nach der empfohlenen Migration von technischen Nutzern zu Confidential Clients den Client-Credentials Flow (`authorization-grant-type: client_credentials`) nutzt.
+Für die TaskScheduler-Konfiguration ist nicht relevant, ob die ClientRegistration den Resource-Owner-Password-Credentials Flow (`authorization-grant-type: password`) oder nach der empfohlenen User-Migration von einem _natürlichen User_ auf ein _technischen Nutzer_ den Client-Credentials Flow (`authorization-grant-type: client_credentials`) nutzt.
 
 .Properties mit technischem Nutzer
 [source,properties]
 ----
-isy.task.tasks.halloWeltTask.registration-id=TestClient
+isy.task.tasks.halloWeltTask.oauth2ClientRegistrationId=TestClient
 
 # [...]
 
@@ -123,7 +123,7 @@ spring.security.oauth2.client.registration.TestClient.client-secret=test-client-
 spring.security.oauth2.client.registration.TestClient.authorization-grant-type=password
 spring.security.oauth2.client.registration.TestClient.provider=TestRealm
 
-# Benutzer, Passwort und BHKNZ werden auf die selbe registration-id abgebildet
+# Benutzer, Passwort und BHKNZ werden auf die selbe oauth2ClientRegistrationId abgebildet
 
 isy.security.oauth2.client.registration.TestClient.username=TestUser
 isy.security.oauth2.client.registration.TestClient.password=TestPasswort
@@ -133,7 +133,7 @@ isy.security.oauth2.client.registration.TestClient.bhknz=TestBHKNZ
 .Properties nach Umstellung von technischem Nutzer auf Confidential Client
 [source,properties]
 ----
-isy.task.tasks.halloWeltTask.registration-id=TestClient
+isy.task.tasks.halloWeltTask.oauth2ClientRegistrationId=TestClient
 
 # [...]
 

--- a/isyfact-standards-doc/src/docs/antora/modules/changelog/pages/migrationsleitfaden.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/changelog/pages/migrationsleitfaden.adoc
@@ -83,6 +83,67 @@ spring.security.oauth2.client.registration.TestClient.provider=TestRealm
 [[kapitel-task-scheduler]]
 === Task Scheduler
 
+In IsyFact 3.0 wurden die Nutzungsvorgaben zur authentifizierung von Tasks aktualisiert, da der Task Scheduling Baustein auf `isy-security` umgestellt wurde.
+Statt Benutzer, Passwort und BHKNZ (siehe <<task-properties-isy-sicherheit>>) muss in den Task Properties nur noch eine `registration-id` konfiguriert werden (siehe <<task-properties-isy-security>>).
+
+[[task-properties-isy-sicherheit]]
+.Properties mit isy-sicherheit in IsyFact 2
+[source,properties]
+----
+isy.task.tasks.halloWeltTask.benutzer=TestUser
+isy.task.tasks.halloWeltTask.passwort=TestPasswort
+isy.task.tasks.halloWeltTask.bhkz=TestBHKNZ
+
+# [...]
+----
+
+[[task-properties-isy-security]]
+.Properties mit isy-security in IsyFact 3
+[source,properties]
+----
+isy.task.tasks.halloWeltTask.registration-id=TestClient
+
+# [...]
+----
+
+Eine entsprechende Spring Security ClientRegistration wird durch `isy-security` xref:isy-security:nutzungsvorgaben/master.adoc#konfigurationsparameter[ Konfigurationsparameter] bereitgestellt.
+Die folgenden Beispiele zeigen wie Konfigurationen nach der Migration aussehen können.
+Für die Task Scheduler konfiguration ist nicht relevant, ob die ClientRegistration den Resource-Owner-Password-Credentials Flow (`authorization-grant-type: password`) oder nach der empfohlenen Migration von technischen Nutzern zu Confidential Clients den Client-Credentials Flow (`authorization-grant-type: client_credentials`) nutzt.
+
+.Properties mit technischem Nutzer
+[source,properties]
+----
+isy.task.tasks.halloWeltTask.registration-id=TestClient
+
+# [...]
+
+spring.security.oauth2.client.provider.TestRealm.issuer-uri=http://localhost:9095/auth/realms/testrealm
+spring.security.oauth2.client.registration.TestClient.client-id=test-client-id
+spring.security.oauth2.client.registration.TestClient.client-secret=test-client-secret
+spring.security.oauth2.client.registration.TestClient.authorization-grant-type=password
+spring.security.oauth2.client.registration.TestClient.provider=TestRealm
+
+# Benutzer, Passwort und BHKNZ werden auf die selbe registration-id abgebildet
+
+isy.security.oauth2.client.registration.TestClient.username=TestUser
+isy.security.oauth2.client.registration.TestClient.password=TestPasswort
+isy.security.oauth2.client.registration.TestClient.bhknz=TestBHKNZ
+----
+
+.Properties nach Umstellung von technischem Nutzer auf Confidential Client
+[source,properties]
+----
+isy.task.tasks.halloWeltTask.registration-id=TestClient
+
+# [...]
+
+spring.security.oauth2.client.provider.TestRealm.issuer-uri=http://localhost:9095/auth/realms/testrealm
+spring.security.oauth2.client.registration.TestClient.client-id=test-user-client-id
+spring.security.oauth2.client.registration.TestClient.client-secret=test-user-client-secret
+spring.security.oauth2.client.registration.TestClient.authorization-grant-type=client_credentials
+spring.security.oauth2.client.registration.TestClient.provider=TestRealm
+----
+
 [[kapitel-service, Bausteine/Service]]
 === Service
 


### PR DESCRIPTION
- [ ] depends on https://github.com/IsyFact/isyfact-standards/pull/42

Beschreibt die zur Migration nötigen Anpassungen an der Konfiguration von Tasks.
Issue: ISY-268