### PR TITLE
hotfix: ISY-54 fix regression in the migrationsleitfaden

### DIFF
--- a/isyfact-standards-doc/src/docs/antora/modules/changelog/pages/migrationsleitfaden.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/changelog/pages/migrationsleitfaden.adoc
@@ -86,7 +86,8 @@ Eine Beschreibung der Parameter findet sich in den xref:isy-security:nutzungsvor
 
 <<table-sicherheit-konfiguration>> gibt eine Übersicht über die zu ändernden Parameter.
 Die `instances[n]` Notation aus den isy-sicherheit-keycloak Properties wird in isy-security nicht länger unterstützt.
-Jede Instanz soll durch einen sprechenden und eindeutigen `provider-name` bzw. eine `oauth2ClientRegistrationId` ersetzt werden.
+Jede Instanz soll durch eine sprechende und eindeutige `registration-id` ersetzt werden.
+Falls mehrere Instanzen für das gleiche Realm konfiguriert wurden, kann der `provider-name` pro Realm einmalig konfiguriert und für mehrer OAuth 2.0 Client Registrations (`registration-id`) wiederverwendet werden.
 
 Aus Platzgründen wurde in der ersten Spalte auf das `isy.sicherheit.keycloak` Präfix verzichtet.
 Analog wurde bei allen Properties der zweiten Spalte, die mit einem Punkt beginnen, auf das Präfix `spring.security.oauth2.client` verzichtet.


### PR DESCRIPTION
Changes in c2b09b33ccdc019d4a32f7d30693761f2083e10e renamed a parameter so it no longer reflects the technical term used by the library spring-security-oauth2-client and also breaks the correlation to the table a few lines below which still uses the old parameter name.
This PR reverts the name and rephrases the sentence to hopefully alleviate potential confusion for users who are not familiar with the library.