### PR TITLE
Revert "ci: configure dependabot to create only patch PRs"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-      time: "22:00"
-      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 5
     groups:
       spring-webflow:
         patterns:
@@ -37,7 +36,7 @@ updates:
           - "com.icegreen.greenmail*"
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "de.bund.bva.isyfact:*"
 
 
@@ -46,8 +45,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-      time: "22:00"
-      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 5
     groups:
       spring-webflow:
         patterns:


### PR DESCRIPTION
Restore previous dependaBot configuration after integrating all available patches successfully.