### PR TITLE
[Sprint 89] ISY-382: Release Isyfact Standards 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 3.0.0
 - `ISY-183`: [isyfact-standards-doc] Migrationsleitfaden zur Entfernung der Bridge-Module
 - `ISY-54`: [isyfact-standards-doc] Migrationsleitfaden zur Umstellung auf isy-security
-  * `ISY-219`: Abschnitt zur Migration der Annotation @NutzerAuthentifizierung
+- `ISY-219`: [isyfact-standards-doc] Abschnitt zur Migration der Annotation @NutzerAuthentifizierung
 - `IFS-2561`: [isy-security] Die Konfiguration via `rollenrechte.xml` erfolgt optional.
   * Initialisierung mit Standardwerten
 - `IFS-1887`: [isyfact-standards-doc] Ergänzung der Nutzungsvorgaben für neuen Sicherheitsbaustein `isy-security`
@@ -12,62 +12,69 @@
 - `IFS-1745`: [isyfact-standards-doc] Summary Architektur- und Sicherheitsregeln
   * mit Antora Extensions generiert
 - `IFS-1702`: [isy-ueberwachung] Refaktorierung ServiceStatistik
-    * Entkoppelt von Micrometer API
-    * Aufgeteilt in Interface und Implementierung
+  * Entkoppelt von Micrometer API
+  * Aufgeteilt in Interface und Implementierung
 - `IFS-1467`: Maven Plugins für statische Informationen:
-    * git-commit-id-plugin (Version 4.9.10)
-    * spring-boot-maven-plugin (Version von spring-boot verwaltet)
+  * git-commit-id-plugin (Version 4.9.10)
+  * spring-boot-maven-plugin (Version von spring-boot verwaltet)
 - `IFS-1628`: [isy-ueberwachung] Standardmetriken bei Anbinden von ServiceStatistik vorhanden
 - `IFS-1947`: Zeichenkodierung für Filtering von properties Dateien im Maven Resource Plugin auf ISO-8859-1 gesetzt.
 - `IFS-771`: [isy-ueberwachung] Anleitung für den HealthCheck von HTTPInvoker-Endpoints hinzugefügt
 - `IFS-1465`: [isyfact-products-bom] Spring Boot Versionsanhebung auf 2.7.1
 - `IFS-2021`: [isyfact-products-bom] Spring Boot Versionsanhebung auf 2.7.9
-  - spring-boot-maven-plugin Versionsanhebung auf 2.7.9
+  * spring-boot-maven-plugin Versionsanhebung auf 2.7.9
 - `IFS-2537`: [isyfact-products-bom] Spring Boot Versionsanhebung auf 2.7.11
-  - spring-boot-maven-plugin Versionsanhebung auf 2.7.11
+  * spring-boot-maven-plugin Versionsanhebung auf 2.7.11
 - `IFS-1073`: [isy-serviceapi-core] Logausgabe zur Korrektur der Korrelations-Id entfernt
 - `IFS-1282`: Einführung von Maven CI-friendly Versionen
 - `IFS-1157`: [isyfact-standards-bom] Module und Sub-Module entfernt:
-    * isy-serviceapi-sst
-    * isy-exception-sst
-    * isy-sst-bridge
+  * isy-serviceapi-sst
+  * isy-exception-sst
+  * isy-sst-bridge
 - `IFS-1148`: [isy-batchrahmen] Fehler wegen zu langem Klassenpfad unter Windows behoben
 - `IFS-1354`: [isy-persistence] Autokonfiguration mit initialisierbarer Datenbank
-    * Für die Konfiguration der DataSource wurde zu den DataSourceProperties von Spring Boot gewechselt. Hierdurch haben sich die Namen der Konfigurationsschlüssel geändert und müssen angepasst werden.
+  * Für die Konfiguration der DataSource wurde zu den DataSourceProperties von Spring Boot gewechselt. Hierdurch haben sich die Namen der Konfigurationsschlüssel geändert und müssen angepasst werden.
 - `IFS-1166`: [isy-serviceapi-core] Autokonfiguration von isy-serviceapi-core nach isy-sicherheit
 - `IFS-1091`: [isy-batchrahmen] Fehlerhafte ExcludeFromBatchContext-Annotation behoben
 - `IFS-1050`: [isy-batchrahmen] Stelle Beispiel-SQL-Skripte wieder her, sodass diese mit der Oracle-Datenbank kompatibel sind
 - `IFS-1548`: [isyfact-standards-doc] Anleitung zum Formatieren und Einrichten des Checkstyle Plugins angepasst
 - `IFS-1552`: Einheitliche Verwendung von Maven-Properties für Versionsnummern
 - `IFS-1504`: [isy-sonderzeichen] Transformator für die normative Abbildung lateinischer Buchstaben auf Grundbuchstaben (Suchform) hinzugefügt
-    * Integration von zugeliefertem Code aus `IFS-1270`
+  * Integration von zugeliefertem Code aus `IFS-1270`
 - `IFS-2045`: [isyfact-products-bom] Produkte Apache Tika, commons-beanutils und commons-io hinzugefügt
 - `IFS-2287`: [isy-sonderzeichen]  Deprecation für String-Latin-1.1-Transformatoren setzen
 - `IFS-1886`: [isy-sicherheit] Modul als `@Deprecated` markiert zugunsten von`isy-security`
 - `IFS-1940`: [isy-sicherheit] `IsySicherheitUtil` deprecated
 - `IFS-2382`: [isy-sonderzeichen] Entfernt Mutable-Array Spotbugs Fehler
-    #### _Breaking Change:_
-    - Die Klassen `stringlatin1_1/core/transformation/ZeichenKategorie.java` und `dinspec91379/transformation/ZeichenKategorie.java` bieten für Abruf aller Möglichkeiten einen `getter` anstelle einer `public static Variable` an
 - `IFS-1169`: [isy-batchrahmen] Änderung von Tabellenname und Spaltennamen der BatchStatus-Tabelle zu `CamelCaseToUnderscoresNamingStrategy`
   * Tabelle `BATCH_STATUS` mit `CamelCaseToUnderscoresNamingStrategy` ersetzt Tabelle `BATCHSTATUS` mit `PhysicalNamingStrategyStandardImpl`
   * explizites ORM für Abwärtskompatibilität bereitgestellt (siehe Dokumentation: Die Konfiguration der Spring-Kontexte)
 - `IFS-1171`: [isy-sonderzeichen] Fehlende Zeichen 0110 und 0111 zum Mapping hinzugefügt
-  #### _Breaking Change:_
-  * Der Zeichensatz für String Latin 1.1 wurde korrigiert. Dies kann zu Kompatibilitätsproblemen in der Kommunikation mit Anwendungen führen, die den unkorrigierten Zeichensatz verwenden. (IsyFact-Versionen kleiner als IF 3)
-- `IFS-2153`: [isyfact-task] Umstellung isy-task auf Spring Boot:
-  #### _BREAKING CHANGE: Einführung von Spring Boot_
-  * Taskkonfiguration und TaskkonfigurationVerwalter entfernt, Übersetzungen hinzugefügt
+- `IFS-2153`: [isy-task] Umstellung isy-task auf Spring Boot
+  * Übersetzungen hinzugefügt
 - `ISY-139`: [isyfact-products-bom] Spring Boot Versionsanhebung auf 2.7.15
 - [isy-sonderzeichen] Hinzufügen eines neuen Packages mit Transformatoren für die DIN Norm 91379
 - `IFS-1853`: [isy-batchrahmen] Umstellung von `isy-sicherheit` und `isy-aufrufkontext` auf neuen Baustein `isy-security`
-  #### _Breaking Change:_
-  * Die Konfiguration von `benutzer`, `passwort` und `bhknz` erfolgt über isy-security ClientRegistrations. Batches müssen nur noch eine `oauth2ClientRegistrationId` zur Authentifizierung bereitstellen. Die Methode `getAuthenticationCredentials` der `BatchAusfuehrungsBean` wurde entfernt.
 - `IFS-2416`: [isyfact-standards-bom] zentrale Versionsverwaltung von `isy-security`
 - `IFS-2416`: [isy-task] Umstellung von isy-sicherheit auf isy-security
-  #### _Breaking Change:_
-  * Die Konfiguration von `benutzer`, `passwort` und `bhknz` erfolgt über isy-security ClientRegistrations und für IsyTaskConfigurationProperties muss nur eine `oauth2ClientRegistrationId` zur Authentifizierung konfiguriert werden.
 - `ISY-372`: [isy-styleguide] JavaScript-Referenzen entfernt
 - `ISY-416`: [isyfact-products-bom] Versionsanhebung von Metro Webservices auf 2.4.9
+
+## BREAKING CHANGE
+
+### isy-sonderzeichen
+- Die Klassen `stringlatin1_1/core/transformation/ZeichenKategorie.java` und `dinspec91379/transformation/ZeichenKategorie.java` bieten für Abruf aller Möglichkeiten einen `getter` anstelle einer `public static Variable` an
+- Der Zeichensatz für String Latin 1.1 wurde korrigiert. Dies kann zu Kompatibilitätsproblemen in der Kommunikation mit Anwendungen führen, die den unkorrigierten Zeichensatz verwenden. (IsyFact-Versionen kleiner als IF 3)
+
+### isy-task 
+
+- Einführung von Spring Boot für Tasks
+  * Taskkonfiguration und TaskkonfigurationVerwalter entfernt
+- Die Konfiguration von `benutzer`, `passwort` und `bhknz` erfolgt über isy-security ClientRegistrations und für IsyTaskConfigurationProperties muss nur eine `oauth2ClientRegistrationId` zur Authentifizierung konfiguriert werden.
+
+### isy-batchrahmen
+
+- Die Konfiguration von `benutzer`, `passwort` und `bhknz` erfolgt über isy-security ClientRegistrations. Batches müssen nur noch eine `oauth2ClientRegistrationId` zur Authentifizierung bereitstellen. Die Methode `getAuthenticationCredentials` der `BatchAusfuehrungsBean` wurde entfernt.
 
 # 2.4.4
 - `IFS-1997`: Fix CVE-2022-42889 durch Anhebung von 'commons-text' auf 1.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,9 @@
 
 - Die Konfiguration von `benutzer`, `passwort` und `bhknz` erfolgt über isy-security ClientRegistrations. Batches müssen nur noch eine `oauth2ClientRegistrationId` zur Authentifizierung bereitstellen. Die Methode `getAuthenticationCredentials` der `BatchAusfuehrungsBean` wurde entfernt.
 
+### isy-persistence
+- Der Konfigurationsschlüssel für die DataSource heißt nun `isy.persistence.datasource` statt `isy.persistence.oracle.datasource`
+
 # 2.4.4
 - `IFS-1997`: Fix CVE-2022-42889 durch Anhebung von 'commons-text' auf 1.10
 

--- a/isy-batchrahmen/pom.xml
+++ b/isy-batchrahmen/pom.xml
@@ -43,9 +43,7 @@
         <dependency>
             <groupId>de.bund.bva.isyfact</groupId>
             <artifactId>isy-security</artifactId>
-            <version>${parent.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-aop</artifactId>

--- a/isy-serviceapi-core/pom.xml
+++ b/isy-serviceapi-core/pom.xml
@@ -177,11 +177,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <scope>test</scope>

--- a/isyfact-standards-doc/src/docs/antora/antora.yml
+++ b/isyfact-standards-doc/src/docs/antora/antora.yml
@@ -1,7 +1,7 @@
 name: isyfact-standards-doku
 title: IsyFact Standards
-version: '3.0.0-SNAPSHOT'
-display_version: '3.0 (DEV)'
+version: '3.0.0'
+display_version: '3.0'
 start_page: einstieg:einstieg.adoc
 nav:
 - modules/einstieg/nav.adoc

--- a/isyfact-standards-doc/src/docs/antora/modules/changelog/pages/migrationsleitfaden.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/changelog/pages/migrationsleitfaden.adoc
@@ -119,6 +119,95 @@ spring.security.oauth2.client.registration.TestClient.provider=TestRealm
 
 Die Bausteine `isy-sicherheit` und `isy-sicherheit-keycloak` werden durch `isy-security` abgelöst.
 
+[[kapitel-task-scheduler]]
+=== Task Scheduler
+
+In IsyFact 3.0 wurden mit der Umstellung auf `isy-security` die Nutzungsvorgaben zur xref:isy-task:nutzungsvorgaben/master.adoc#spring-konfiguration[Authentifizierung von Tasks] aktualisiert.
+Statt Benutzer, Passwort und BHKNZ (siehe <<task-properties-isy-sicherheit>>) muss in den Task Properties eine `oauth2ClientRegistrationId` konfiguriert werden (siehe <<task-properties-isy-security>>).
+
+[[task-properties-isy-sicherheit]]
+.Properties mit isy-sicherheit in IsyFact 2
+[source,properties]
+----
+isy.task.tasks.halloWeltTask.benutzer=TestUser
+isy.task.tasks.halloWeltTask.passwort=TestPasswort
+isy.task.tasks.halloWeltTask.bhkz=TestBHKNZ
+
+# [...]
+----
+
+[[task-properties-isy-security]]
+.Properties mit isy-security in IsyFact 3
+[source,properties]
+----
+isy.task.tasks.halloWeltTask.oauth2ClientRegistrationId=TestClient
+
+# [...]
+----
+
+Eine entsprechende Spring Security ClientRegistration wird durch `isy-security` xref:isy-security:nutzungsvorgaben/master.adoc#konfigurationsparameter[ Konfigurationsparameter] bereitgestellt.
+Die folgenden Beispiele zeigen wie Konfigurationen nach der Migration aussehen können.
+Für die TaskScheduler-Konfiguration ist nicht relevant, ob die ClientRegistration den Resource-Owner-Password-Credentials Flow (`authorization-grant-type: password`) oder nach der empfohlenen User-Migration von einem _natürlichen User_ auf ein _technischen Nutzer_ den Client-Credentials Flow (`authorization-grant-type: client_credentials`) nutzt.
+
+.Properties mit technischem Nutzer
+[source,properties]
+----
+isy.task.tasks.halloWeltTask.oauth2ClientRegistrationId=TestClient
+
+# [...]
+
+spring.security.oauth2.client.provider.TestRealm.issuer-uri=http://localhost:9095/auth/realms/testrealm
+spring.security.oauth2.client.registration.TestClient.client-id=test-client-id
+spring.security.oauth2.client.registration.TestClient.client-secret=test-client-secret
+spring.security.oauth2.client.registration.TestClient.authorization-grant-type=password
+spring.security.oauth2.client.registration.TestClient.provider=TestRealm
+
+# Benutzer, Passwort und BHKNZ werden auf die selbe oauth2ClientRegistrationId abgebildet
+
+isy.security.oauth2.client.registration.TestClient.username=TestUser
+isy.security.oauth2.client.registration.TestClient.password=TestPasswort
+isy.security.oauth2.client.registration.TestClient.bhknz=TestBHKNZ
+----
+
+.Properties nach Umstellung von _technischem Nutzer_ auf _technischen Client_
+[source,properties]
+----
+isy.task.tasks.halloWeltTask.oauth2ClientRegistrationId=TestClient
+
+# [...]
+
+spring.security.oauth2.client.provider.TestRealm.issuer-uri=http://localhost:9095/auth/realms/testrealm
+spring.security.oauth2.client.registration.TestClient.client-id=test-user-client-id
+spring.security.oauth2.client.registration.TestClient.client-secret=test-user-client-secret
+spring.security.oauth2.client.registration.TestClient.authorization-grant-type=client_credentials
+spring.security.oauth2.client.registration.TestClient.provider=TestRealm
+----
+
+[[kapitel-service, Bausteine/Service]]
+=== Service
+
+[WARNING]
+====
+Ab IsyFact 3 ist die *Verwendung von REST-Schnittstellen* für die Neuentwicklung verbindlich.
+Spring HTTP-Invoker ist deprecated und wird ab sofort als Schnittstellenformat durch REST abgelöst.
+Die Verwendung von REST-Schnittstellen wird im Baustein REST (siehe xref:isy-service-rest:konzept/master.adoc[] und xref:isy-service-rest:nutzungsvorgaben/master.adoc[]) erläutert.
+Desweiteren wurden die Bridge-Module `isy-serviceapi-core-bridge`, `isy-serviceapi-sst-bridge` und `isy-exception-sst-bridge` entfernt.
+
+====
+
+[WARNING]
+====
+Mit der Verwendung von `isy-security` in der IsyFact 3 wird standardmäßig anstelle von IsyFacts `AufrufKontext` Springs `SecurityContext` verwendet.
+
+Damit dennoch alte HTTP-Invoker Schnittstellen aufgerufen werden können (welche einen gefüllten AufrufKontext benötigen), wird eine spezielle `RemoteInvocationFactory` eingesetzt, welche Springs `SecurityContext` in ein `AufrufKontextTo` ad hoc per Request umwandelt.
+
+Weitere Informationen können unter
+xref:isy-serviceapi-core:nutzungsvorgaben/inhalt.adoc#kompatibilitaet_if1_2_3[Nutzungsvorgaben HTTP-Invoker] nachgelesen werden.
+====
+
+[[kapitel-sicherheit]]
+=== Sicherheit
+
 [[sicherheit-konfiguration]]
 ==== Konfiguration
 
@@ -401,96 +490,6 @@ Die Änderungen der Methodensignaturen sind in den nachfolgenden Tabellen beschr
 |`public String getAccessTokenResponse(AccessToken accessToken)`|`public String getAccessTokenResponse(JwtClaimsSet claims)`|geänderter Parametertyp
 
 |===
-
-[[kapitel-task-scheduler]]
-=== Task Scheduler
-
-In IsyFact 3.0 wurden mit der Umstellung auf `isy-security` die Nutzungsvorgaben zur xref:isy-task:nutzungsvorgaben/master.adoc#spring-konfiguration[Authentifizierung von Tasks] aktualisiert.
-Statt Benutzer, Passwort und BHKNZ (siehe <<task-properties-isy-sicherheit>>) muss in den Task Properties eine `oauth2ClientRegistrationId` konfiguriert werden (siehe <<task-properties-isy-security>>).
-
-[[task-properties-isy-sicherheit]]
-.Properties mit isy-sicherheit in IsyFact 2
-[source,properties]
-----
-isy.task.tasks.halloWeltTask.benutzer=TestUser
-isy.task.tasks.halloWeltTask.passwort=TestPasswort
-isy.task.tasks.halloWeltTask.bhkz=TestBHKNZ
-
-# [...]
-----
-
-[[task-properties-isy-security]]
-.Properties mit isy-security in IsyFact 3
-[source,properties]
-----
-isy.task.tasks.halloWeltTask.oauth2ClientRegistrationId=TestClient
-
-# [...]
-----
-
-Eine entsprechende Spring Security ClientRegistration wird durch `isy-security` xref:isy-security:nutzungsvorgaben/master.adoc#konfigurationsparameter[ Konfigurationsparameter] bereitgestellt.
-Die folgenden Beispiele zeigen wie Konfigurationen nach der Migration aussehen können.
-Für die TaskScheduler-Konfiguration ist nicht relevant, ob die ClientRegistration den Resource-Owner-Password-Credentials Flow (`authorization-grant-type: password`) oder nach der empfohlenen User-Migration von einem _natürlichen User_ auf ein _technischen Nutzer_ den Client-Credentials Flow (`authorization-grant-type: client_credentials`) nutzt.
-
-.Properties mit technischem Nutzer
-[source,properties]
-----
-isy.task.tasks.halloWeltTask.oauth2ClientRegistrationId=TestClient
-
-# [...]
-
-spring.security.oauth2.client.provider.TestRealm.issuer-uri=http://localhost:9095/auth/realms/testrealm
-spring.security.oauth2.client.registration.TestClient.client-id=test-client-id
-spring.security.oauth2.client.registration.TestClient.client-secret=test-client-secret
-spring.security.oauth2.client.registration.TestClient.authorization-grant-type=password
-spring.security.oauth2.client.registration.TestClient.provider=TestRealm
-
-# Benutzer, Passwort und BHKNZ werden auf die selbe oauth2ClientRegistrationId abgebildet
-
-isy.security.oauth2.client.registration.TestClient.username=TestUser
-isy.security.oauth2.client.registration.TestClient.password=TestPasswort
-isy.security.oauth2.client.registration.TestClient.bhknz=TestBHKNZ
-----
-
-.Properties nach Umstellung von _technischem Nutzer_ auf _technischen Client_
-[source,properties]
-----
-isy.task.tasks.halloWeltTask.oauth2ClientRegistrationId=TestClient
-
-# [...]
-
-spring.security.oauth2.client.provider.TestRealm.issuer-uri=http://localhost:9095/auth/realms/testrealm
-spring.security.oauth2.client.registration.TestClient.client-id=test-user-client-id
-spring.security.oauth2.client.registration.TestClient.client-secret=test-user-client-secret
-spring.security.oauth2.client.registration.TestClient.authorization-grant-type=client_credentials
-spring.security.oauth2.client.registration.TestClient.provider=TestRealm
-----
-
-[[kapitel-service, Bausteine/Service]]
-=== Service
-
-[WARNING]
-====
-Ab IsyFact 3 ist die *Verwendung von REST-Schnittstellen* für die Neuentwicklung verbindlich.
-Spring HTTP-Invoker ist deprecated und wird ab sofort als Schnittstellenformat durch REST abgelöst.
-Die Verwendung von REST-Schnittstellen wird im Baustein REST (siehe xref:isy-service-rest:konzept/master.adoc[] und xref:isy-service-rest:nutzungsvorgaben/master.adoc[]) erläutert.
-Desweiteren wurden die Bridge-Module `isy-serviceapi-core-bridge`, `isy-serviceapi-sst-bridge` und `isy-exception-sst-bridge` entfernt.
-
-====
-
-[WARNING]
-====
-Mit der Verwendung von `isy-security` in der IsyFact 3 wird standardmäßig anstelle von IsyFacts `AufrufKontext` Springs `SecurityContext` verwendet.
-
-Damit dennoch alte HTTP-Invoker Schnittstellen aufgerufen werden können (welche einen gefüllten AufrufKontext benötigen), wird eine spezielle `RemoteInvocationFactory` eingesetzt, welche Springs `SecurityContext` in ein `AufrufKontextTo` ad hoc per Request umwandelt.
-
-Weitere Informationen können unter
-xref:isy-serviceapi-core:nutzungsvorgaben/inhalt.adoc#kompatibilitaet_if1_2_3[Nutzungsvorgaben HTTP-Invoker] nachgelesen werden.
-====
-
-[[kapitel-sicherheit]]
-=== Sicherheit
-
 
 [[kapitel-dokumentation]]
 == Dokumentation

--- a/isyfact-standards-doc/src/docs/antora/modules/changelog/pages/releasenotes.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/changelog/pages/releasenotes.adoc
@@ -8,7 +8,7 @@ include::glossary:licence:partial$licence.adoc[]
 *Übersicht über die Änderungen*
 
 [[kapitel-aenderungen]]
-== Änderungen
+== Allgemeine Änderungen
 
 [[kapitel-umstellung-dokumentation]]
 === Umstellung der Dokumentation
@@ -22,12 +22,13 @@ Produktkatalog als Teil der Dokumentation:: Der xref:einstieg:produkte.adoc[Prod
 
 [[kapitel-spring-boot]]
 === Spring Boot
+Spring Boot wurde auf Version 2.7.15 angehoben. Die Versionen sämtlicher Produkte werden ebenfalls von Spring verwaltet (s. https://docs.spring.io/spring-boot/docs/2.7.15/reference/html/dependency-versions.html).
 
 [[kapitel-java]]
 === Java
 
-Java Runtime:: Die Java Runtime Environment wurde auf Version 17 gehoben. 
-Es ist gegen Version 8 zu kompilieren. 
+Java Runtime:: Die Java Runtime Environment wurde auf Version 17 gehoben.
+Es ist aber weiterhin mit Version 8 zu kompilieren (Language Level).
 Java Vendor:: Der Java Vendor wurde geändert auf Eclipse Temurin satt Oracle RedHat.
 
 [[kapitel-rest-interne-externe-schnittstelle]]
@@ -35,9 +36,30 @@ Java Vendor:: Der Java Vendor wurde geändert auf Eclipse Temurin satt Oracle Re
 
 REST Schnittstellen:: Sowohl interne als auch externe REST-Schnittstellen sind ab sofort einheitlich nach dem xref:isy-service-rest:konzept/master.adoc[REST-Konzept] zu realisieren.
 Spring HTTPInvoker deprecated icon:ban[title=Deprecation]:: Die Verwendung von xref:isy-serviceapi-core:konzept/master.adoc[HTTPInvoker Schnittstellen] gilt als deprecated und wird mit einem nachfolgenden Release entfernt.
-Metadaten im HTTP-Header statt im Datensatz/Aufrufkontext icon:ban[title=Deprecation]:: Metadaten sind über HTTP-Header zur realisieren. 
+Metadaten im HTTP-Header statt im Datensatz/Aufrufkontext icon:ban[title=Deprecation]:: Metadaten sind über HTTP-Header zur realisieren.
 Eine Verwendung von Metadaten über HTTPInvoker und Aufrufkontext gilt als deprecated und wird mit einem nachfolgenden Release entfernt.
 REST-Baustein als http-Invoker Nachfolger:: Der REST-Baustein wird als Nachfolger des HTTPInvoker-Bausteins (isy-serviceapi-core) veröffentlicht.
+
+[[kapitel-sles]]
+=== Suse Linux Enterprise Server (SLES)
+
+Der Standard schreibt nun statt eines Betriebssystems diejenigen Produkte vor, die zum Bau und zum Betrieb der Anwendungen nötig sind.
+
+Suse Linux Enterprise Server (SLES) entfernt:: Das Betriebssystem wurde aus dem Produktkatalog und der Dokumentation entfernt.
+Eclipse Temurin als JVM aufgenommen:: siehe <<kapitel-java>>
+
+[[kapitel-liquibase]]
+=== Liquibase
+
+Liquibase in Produktkatalog aufgenommen:: Einführung und Umstellung auf Liquibase.
+Ausblick:: Die konzeptionelle Integration erfolgt in einem nachfolgenden Release.
+
+[[kapitel-optimierung-dependeny-management]]
+=== Optimierung Dependency Management
+Abhängigkeiten wurden überprüft und reduziert.
+
+[[kapitel-aenderungen]]
+== Isyfact Bausteine
 
 [[kapitel-baustein-sicherheit-deprecated]]
 === Baustein Sicherheit deprecated icon:ban[title=Deprecation]
@@ -62,12 +84,9 @@ Im neuen xref:isy-security:konzept/master.adoc[Baustein Security] werden die sic
 Ablösung von sicherheitsrelevanten IsyFact-Annotationen::
 Die von Spring Security bereitgestellte Annotation `@secured` löst die Annotation `@gesichert` ab und ist analog dazu zu verwenden.
 
-//TODO klären, ob hier aufzunehmen
-[[kapitel-keycloak]]
-=== Keycloak 17-19
-
 [[kapitel-neue-endpoints-ueberwachung]]
-=== Neue Endpoints in Baustein Überwachung
+=== Baustein Überwachung
+==== Neue Endpoints in Baustein Überwachung
 Liveness, Readiness und Availability zur Überwachung:: Liveness und Readiness bieten ein feingranulares Monitoring der health eines Systems. 
 Diese Endpoints stehen zusätzlich zu den vorhandenen Health-Endpoints zur Verfügung und sind im xref:isy-ueberwachung:konzept/master.adoc[Konzept des Bausteins Überwachung] definiert.
 Die xref:isy-ueberwachung:nutzungsvorgaben/master.adoc[Nutzungsvorgaben des Bausteins Überwachung] wurden um  Implementierungshinweise erweitert. 
@@ -76,66 +95,67 @@ Availability wird als erweiterte Überwachungsmetrik aufbauend auf Liveness und 
 Diese fachlichen Möglichkeiten funktionieren auch mit Liveness und Readiness Probes. 
 Damit sind differenzierte Reaktionen auf Fehler in den Systemen möglich.
 
-//TODO ist das überhaupt ein Baustein für die OS Dokumentation??
-[[kapitel-neuer-baustein-angular]]
-=== Neuer Baustein Angular
-
-//TODO Oder ist Node allgemein und muss separat beschrieben werden?
-Versionshebung Node v18:: 
-Versionshebung Angular v13::
-Versionshebung PrimeNG v13::
-Baustein mit Angular PrimeNG und Bootstrap deprecated icon:ban[title=Deprecation]:: Der Baustein mit Angular PrimeNG und Bootstrap ist deprecated. 
+==== Refactoring der `ServiceStatistik`
+Die Klasse `ServiceStatistik` ist nun ein Interface und ermöglicht es, Klassen zum Sammeln von Metriken zu erstellen.
+Alle `ServiceStatistik` implementierenden Beans werden automatisch der Micrometer-Registry hinzugefügt.
+Details finden sich in den xref:isy-ueberwachung:nutzungsvorgaben/master.adoc[Nutzungsvorgaben des Bausteins Überwachung].
 
 [[kapitel-task-scheduling]]
-=== Task Scheduling
+=== Baustein Task Scheduling
 
 Umstellung auf Spring Boot:: Das Task Scheduling wurde auf Spring Boot umgestellt und hat Auswirkungen auf den xref:isy-konfiguration:konzept/master.adoc[Baustein Konfiguration] und den xref:isy-konfiguration:konzept/master.adoc[Baustein Überwachung].
 
 Verwendung des Bausteins isy-security zur Authentifizierung:
 Für die Authentifizierung nutzt der Baustein Task Scheduling die xref:isy-security:konzept/master.adoc#aussensicht-der-komponente-security[Schnittstelle zur Authentifizierung] aus dem xref:isy-security:konzept/master.adoc#absicherung-task[Baustein Security].
-Die bisherige Art der Authentifizierung des Tasks als 'technischer Nutzer' (mit Nutzername u. Passwort) wird perspektivisch durch eine Authentifizierung als 'Client' (mit Client-ID u. -Secret, vergeben vom IAM-System) abgelöst.
-Für eine weiche Migration bietet die Konfiguration von Batches dazu die Möglichkeit, alternativ die Authentifizierungs-Credentials Nutzername & Passwort, analog zur IsyFact 2, bzw. Client-ID & Client-Secret zu setzen.
+Die bisherige Art der Authentifizierung des Tasks als 'technischer Nutzer' (mit Nutzername und Passwort) wird perspektivisch durch eine Authentifizierung als 'Client' (mit Client-ID und Client-Secret, vergeben vom IAM-System) abgelöst.
+Für eine weiche Migration bietet die Konfiguration von Tasks dazu die Möglichkeit, alternativ die Authentifizierungs-Credentials Nutzername und Passwort zusätzlich zu Client-ID und Client-Secret zu setzen um vorübergehend den Resource Owner Password Flow zu nutzen.
 
 [[kapitel-batchrahmen]]
-=== Batchrahmen
-
+=== Baustein Batchrahmen
 Verwendung des Bausteins isy-security zur Authentifizierung:
 Für die Authentifizierung nutzt der Batchrahmen die xref:isy-security:konzept/master.adoc#aussensicht-der-komponente-security[Schnittstelle zur Authentifizierung] aus dem xref:isy-security:konzept/master.adoc#absicherung-task[Baustein Security].
-Die bisherige Art der Authentifizierung des Tasks als 'technischer Nutzer' (mit Nutzername u. Passwort) wird perspektivisch durch eine Authentifizierung als 'Client' (mit Client-ID u. -Secret, vergeben vom IAM-System) abgelöst.
-Für eine weiche Migration bietet die Konfiguration von Batches dazu die Möglichkeit, alternativ die Authentifizierungs-Credentials Nutzername & Passwort, analog zur IsyFact 2, bzw. Client-ID & Client-Secret zu setzen.
+Die bisherige Art der Authentifizierung des Tasks als 'technischer Nutzer' (mit Nutzername und Passwort) wird perspektivisch durch eine Authentifizierung als 'Client' (mit Client-ID und Client-Secret, vergeben vom IAM-System) abgelöst.
+Für eine weiche Migration bietet die Konfiguration von Batches dazu die Möglichkeit, alternativ die Authentifizierungs-Credentials Nutzername und Passwort zusätzlich zu Client-ID und Client-Secret zu setzen um vorübergehend den Resource Owner Password Flow zu nutzen.
+
+Breaking Change: Methode `getAuthenticationCredentials` entfernt::
+Die Konfiguration von `benutzer`, `passwort` und `bhknz` erfolgt über isy-security ClientRegistrations. Batches müssen nur noch eine `oauth2ClientRegistrationId` zur Authentifizierung bereitstellen. Die Methode `getAuthenticationCredentials` der `BatchAusfuehrungsBean` wurde entfernt.
 
 
-[[kapitel-sles]]
-=== Suse Linux Enterprise Server (SLES)
+[[kapitel-sonderzeichen]]
+=== Baustein Sonderzeichen
+Sonderzeichen Transformator::
+Es wurde ein Sonderzeichen Transformator eingeführt um Zeichenketten, welche aus normativen Buchstaben (Datentyp C) der DIN SPEC 91379 bestehen, auf die Grundbuchstaben A-Z abzubilden.
+Für unterschiedliche Anwendungsfälle kann es erforderlich sein, die in Namen enthaltenden Buchstaben auf die Grundbuchstaben A-Z abzubilden.
+Dies ist bspw. der Fall in der maschinenlesbaren Zone (MRZ) amtlicher Reisedokumente, für die der Standard [ICAO 9303-3] einschlägig ist, da nur diese Grundbuchstaben für die Repräsentation von Namen zur Verfügung stehen.
+Wenn Datensätze und Suchanfragen unter Anwendung der Suchform normalisiert werden, ist es auch möglich, Namen trotz unterschiedlicher Schreibweisen zu identifizieren.
 
-Der Standard schreibt nun statt eines Betriebssystems diejenigen Produkte vor, die zum Bau und zum Betrieb der Anwendungen nötig sind.
+String-Latin-1.1 Transformatoren sind nun deprecated icon:ban[title=Deprecation]::
+Der Zeichensatz für String Latin 1.1 wurde korrigiert. Dies kann zu Kompatibilitätsproblemen in der Kommunikation
+mit Anwendungen führen, die den unkorrigierten Zeichensatz verwenden (IsyFact-Versionen kleiner als IF 3).
 
-Suse Linux Enterprise Server (SLES) entfernt:: Das Betriebssystem wurde aus dem Produktkatalog und der Dokumentation entfernt. 
-Eclipse Temurin als JVM aufgenommen:: siehe <<kapitel-java>>
+Breaking Change: Getter eingeführt::
+Die Klassen `stringlatin1_1/core/transformation/ZeichenKategorie.java` und `dinspec91379/transformation/ZeichenKategorie.java` bieten für den Abruf aller Möglichkeiten nun einen `getter` anstelle einer `public static Variable` an.
 
-[[kapitel-liquibase]]
-=== Liquibase
+Außerdem wurden die fehlenden Zeichen 0110 und 0111 zum Mapping hinzugefügt.
 
-Liquibase in Produktkatalog aufgenommen:: Einführung und Umstellung auf Liquibase. 
-Ausblick:: Die konzeptionelle Integration erfolgt in einem nachfolgenden Release. 
 
-[[kapitel-optimierung-dependeny-management]]
-=== Optimierung Dependency Management
-Abhängigkeiten wurden überprüft und reduziert.
+=== Baustein Persistence
+In `isy-persistence` gibt es nun eine Autokonfiguration mit initialisierbarer Datenbank.
+Für die Konfiguration der `DataSource` wurde zu den `DataSourceProperties` von Spring Boot gewechselt.
+
+Breaking Change: Property `DataSource`::
+Der Konfigurationsschlüssel für die `DataSource` heißt nun `isy.persistence.datasource` statt `isy.persistence.oracle.datasource`.
 
 [[kapitel-restrukturierung-bedienkonzept]]
-=== Restrukturierung Bedienkonzept
-
-=== Redis
+=== Styleguide
+Der Styleguide bzw. das Bedienkonzept ist deprecated icon:ban[title=Deprecation]::
+Das bestehende Konzept soll bei der Entwicklung neuer Anwendungen nicht mehr berücksichtigt werden.
+Das neue, restrukturierte Bedienkonzept wird an anderer Stelle veröffentlicht.
 
 [[kapitel-weitere-deprecations]]
 == Weitere Deprecations
-
-[[kapitel-session-management]]
-=== Session Management
-
-[[kapitel-jsf]]
-=== JSF
+* Session Management
+* JSF
 
 [[kapitel-entfernt]]
 == Entfernt
@@ -143,4 +163,17 @@ Abhängigkeiten wurden überprüft und reduziert.
 [[kapitel-vorlageanwendungen]]
 === Vorlageanwendungen
 
-Die Vorlageanwendungen wurden aus der Dokumentation entfernt. 
+Die Vorlageanwendungen wurden aus der Dokumentation entfernt.
+
+=== Bridge-Module
+
+Die Bridge zwischen Isyfact 1 und 2 ist obsolet weshalb folgende Module entfernt wurden:
+
+* isy-serviceapi-sst
+* isy-exception-sst
+* isy-sst-bridge
+
+[[kapitel-produkte]]
+== Produktkatalog
+
+Es gab einige Updates im Produktkatalog. Diese können der xref:einstieg:produktkatalog/changelog.adoc[Änderungshistorie] entnommen werden.


### PR DESCRIPTION
* chore: ISY-382 updates CHANGELOG.md
* docs: ISY-382 bumps version to 3.0.0
* docs: ISY-382 corrects chapter
* build: ISY-382 organize dependencies
* docs: ISY-382 adds release notes and restructure chapters
    * notes for Spring Boot, Styleguide, Persistence
    * adapt description for migration of Batchrahmen and Task-Scheduling
    * new Chapter "Isyfact Bausteine" with similar headlines
* docs: ISY-382 adds breaking change to changelog