### PR TITLE
ISY-612: (ehemals IFS-2044) Update Open CSV 5.7.1 (IF 2.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2.5.0
 - `IFS-1583`: [isy-persistence] `IsyPersistenceOracleAutoConfiguration` verwendet relaxed-binding für ConditionalOnProperty
-- - [isy-sonderzeichen] Hinzufügen eines neuen Packages mit Transformatoren für die DIN Norm 91379
+- [isy-sonderzeichen] Hinzufügen eines neuen Packages mit Transformatoren für die DIN Norm 91379
 - `IFS-2044`: [isyfact-products-bom] OpenCSV Versionsanhebung auf 5.7.1
 
 # 2.4.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 2.5.0
 - `IFS-1583`: [isy-persistence] `IsyPersistenceOracleAutoConfiguration` verwendet relaxed-binding für ConditionalOnProperty
 - - [isy-sonderzeichen] Hinzufügen eines neuen Packages mit Transformatoren für die DIN Norm 91379
-- `IFS-2044`: OpenCSV Versionsanhebung auf 5.7.1
+- `IFS-2044`: [isyfact-products-bom] OpenCSV Versionsanhebung auf 5.7.1
 
 # 2.4.4
 - `IFS-1997`: Fix CVE-2022-42889 durch Anhebung von 'commons-text' auf 1.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.5.0
 - `IFS-1583`: [isy-persistence] `IsyPersistenceOracleAutoConfiguration` verwendet relaxed-binding für ConditionalOnProperty
 - - [isy-sonderzeichen] Hinzufügen eines neuen Packages mit Transformatoren für die DIN Norm 91379
+- `IFS-2044`: OpenCSV Versionsanhebung auf 5.7.1
 
 # 2.4.4
 - `IFS-1997`: Fix CVE-2022-42889 durch Anhebung von 'commons-text' auf 1.10

--- a/isyfact-products-bom/CHANGELOG.md
+++ b/isyfact-products-bom/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2.4.5
+# 2.5.0
 - `IFS-2044`: OpenCSV Versionsanhebung auf 5.7.1
 
 # 2.4.2

--- a/isyfact-products-bom/CHANGELOG.md
+++ b/isyfact-products-bom/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.4.5
+- `IFS-2044`: OpenCSV Versionsanhebung auf 5.7.1
+
 # 2.4.2
 - `IFS-1466`: Versionsanhebung von Spring Boot auf 2.5.13
 - `IFS-1525`: Versionsanhebung von Spring Boot auf 2.5.14

--- a/isyfact-products-bom/pom.xml
+++ b/isyfact-products-bom/pom.xml
@@ -220,7 +220,7 @@
             <dependency>
                 <groupId>com.opencsv</groupId>
                 <artifactId>opencsv</artifactId>
-                <version>5.5.2</version>
+                <version>5.7.1</version>
             </dependency>
 
             <!-- Utility API: Guava -->


### PR DESCRIPTION
update OpenCSV to 5.7.1. This version doesn't include commons-text with CVE's anymore.