### PR TITLE
refactor: ISY-536: solve sonarcloud security issue

### DIFF
--- a/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/common/konstanten/EreignisSchluessel.java
+++ b/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/common/konstanten/EreignisSchluessel.java
@@ -21,6 +21,7 @@ package de.bund.bva.isyfact.ueberwachung.common.konstanten;
  */
 public class EreignisSchluessel {
 
+    private EreignisSchluessel() {}
     /** Standard-Ereignis für Debug/Info-Ausgaben ohne eigene Ereignis-ID. */
     public static final String PLUEB00001 = "PLUEB00001";
 
@@ -38,6 +39,9 @@ public class EreignisSchluessel {
      * @deprecated Wird nicht mehr verwendet. */
     @Deprecated
     public static final String PLUEB00004 = "PLUEB00004";
+
+    /** Loadbalancer wurde abgefragt, aber isAlive-Datei existiert, aber es konnte keine Antwort gesendet werden */
+    public static final String IS_ALIVE_EXISTIERT_IO_EXCEPTION = "PLUEB00006";
 
     /** Loadbalancer wurde abgefragt, aber isAlive-Datei existiert nicht. */
     public static final String IS_ALIVE_EXISTIERT_NICHT = "PLUEB00005";

--- a/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/service/loadbalancer/LoadbalancerServlet.java
+++ b/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/service/loadbalancer/LoadbalancerServlet.java
@@ -88,11 +88,18 @@ public class LoadbalancerServlet extends HttpServlet {
      *             Wenn die Antwort nicht geschrieben werden kann.
      */
     @Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
         if (isAliveFile.exists()) {
             LOG.debug("IsAlive-Datei gefunden, sende HTTP OK.");
             resp.setStatus(HttpServletResponse.SC_OK);
-            resp.getWriter().write("<html><body><center>IS ALIVE!</center></body></html>");
+            try {
+                resp.getWriter().write("<html><body><center>IS ALIVE!</center></body></html>");
+            } catch (IOException e) {
+                LOG.error(
+                        EreignisSchluessel.IS_ALIVE_EXISTIERT_IO_EXCEPTION,
+                        "IsyAlive-Datei {} existiert, fehler bei schreiben der Antwort in output-stream", isAliveFile.getAbsolutePath());
+                resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            }
         } else {
             LOG.error(
                     EreignisSchluessel.IS_ALIVE_EXISTIERT_NICHT,

--- a/isy-ueberwachung/src/test/java/de/bund/bva/isyfact/ueberwachung/service/loadbalancer/TestLoadbalancerServlet.java
+++ b/isy-ueberwachung/src/test/java/de/bund/bva/isyfact/ueberwachung/service/loadbalancer/TestLoadbalancerServlet.java
@@ -77,7 +77,7 @@ public class TestLoadbalancerServlet {
 	
 	
 	@Test
-	public void testDoGet() throws ServletException, IOException {
+	public void testDoGet() throws ServletException {
 		when(mockContext.getRealPath("/src/test/resources")).thenReturn("/src/test/resources/isAlive");
 		when(mockConfig.getInitParameter("isAliveFileLocation")).thenReturn("/src/test/resources");
 		loadBalancer.init(mockConfig);	


### PR DESCRIPTION
Behebe das einzige Security Issue. Eigentlich trivial, weil der Fall wahrscheinlich nie eintritt, dass an der Codestelle eine IOException entsteht, dennoch ist es aus verschiednen Gründen schlecht eine Exception bei doGet nach Außen zu reichen.