### PR TITLE
build: ISY-693 bumb ch.qos.logback from 1.2.12 to 1.2.13

### DIFF
--- a/isyfact-products-bom/pom.xml
+++ b/isyfact-products-bom/pom.xml
@@ -26,8 +26,8 @@
         <tomahawk20.version>1.1.14</tomahawk20.version>
         <javax.el-api.version>3.0.0</javax.el-api.version>
         <metro.webservices.version>2.4.10</metro.webservices.version>
-        <logback-classic.version>1.2.12</logback-classic.version>
-        <logback-core.version>1.2.12</logback-core.version>
+        <logback-classic.version>1.2.13</logback-classic.version>
+        <logback-core.version>1.2.13</logback-core.version>
         <logback-json-classic.version>0.1.5</logback-json-classic.version>
         <logback-jackson.version>0.1.5</logback-jackson.version>
         <ojdbc8.version>19.11.0.0</ojdbc8.version>


### PR DESCRIPTION
 bumb ch.qos.logback:logback-classic and ch.qos.logback:logback-core to fix CVE-2023-6378/CVE-2023-6481.