### PR TITLE
[Sprint 93] ISY-650 (IF 2.x): Auslesen X-Correlation-ID Header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [isy-sonderzeichen] Hinzufügen eines neuen Packages mit Transformatoren für die DIN Norm 91379
 - `IFS-2044`: [isyfact-products-bom] OpenCSV Versionsanhebung auf 5.7.1
 - `ISY-546`: [isy-sicherheit] Abräumen des SecurityContexts im NutzerAuthentifizierungInterceptor
+- `ISY-650`: [isy-aufrufkontext] `FilterRegistrationBean<HttpHeaderNestedDiagnosticContextFilter>` überschreibbar
 
 # 2.4.4
 - `IFS-1997`: Fix CVE-2022-42889 durch Anhebung von 'commons-text' auf 1.10

--- a/isy-aufrufkontext/CHANGELOG.md
+++ b/isy-aufrufkontext/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.5.0
+- `ISY-650`: `FilterRegistrationBean<HttpHeaderNestedDiagnosticContextFilter>` überschreibbar
+
 # 2.4.3
 
 - `IFS-1161`: `HttpHeaderNestedDiagnosticContextFilter` Priorität erhöht

--- a/isy-aufrufkontext/src/main/java/de/bund/bva/isyfact/aufrufkontext/autoconfigure/MdcFilterAutoConfiguration.java
+++ b/isy-aufrufkontext/src/main/java/de/bund/bva/isyfact/aufrufkontext/autoconfigure/MdcFilterAutoConfiguration.java
@@ -1,5 +1,6 @@
 package de.bund.bva.isyfact.aufrufkontext.autoconfigure;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -20,6 +21,7 @@ public class MdcFilterAutoConfiguration {
      * Automatically sets the Correlation-ID
      */
     @Bean
+    @ConditionalOnMissingBean(name = "httpHeaderNestedDiagnosticContextFilter")
     FilterRegistrationBean<HttpHeaderNestedDiagnosticContextFilter> httpHeaderNestedDiagnosticContextFilter() {
         FilterRegistrationBean<HttpHeaderNestedDiagnosticContextFilter> registrationBean =
                 new FilterRegistrationBean<>();

--- a/isy-aufrufkontext/src/test/java/de/bund/bva/isyfact/aufrufkontext/autoconfigure/MdcFilterAutoConfigurationOverrideFilterRegistrationBeanTest.java
+++ b/isy-aufrufkontext/src/test/java/de/bund/bva/isyfact/aufrufkontext/autoconfigure/MdcFilterAutoConfigurationOverrideFilterRegistrationBeanTest.java
@@ -1,0 +1,53 @@
+package de.bund.bva.isyfact.aufrufkontext.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import de.bund.bva.isyfact.aufrufkontext.http.HttpHeaderNestedDiagnosticContextFilter;
+import de.bund.bva.isyfact.aufrufkontext.test.config.LeereTestConfig;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+        classes = {
+                LeereTestConfig.class,
+                MdcFilterAutoConfigurationOverrideFilterRegistrationBeanTest.OverrideTestConfig.class
+        },
+        properties = {
+                "spring.main.banner-mode = off",
+                "isy.logging.anwendung.name = test",
+                "isy.logging.anwendung.typ = test",
+                "isy.logging.anwendung.version = test"
+        })
+public class MdcFilterAutoConfigurationOverrideFilterRegistrationBeanTest {
+
+    @Autowired
+    private FilterRegistrationBean<HttpHeaderNestedDiagnosticContextFilter> mdcFilter;
+
+    @Test
+    public void testThatBeanCanBeOverridden() {
+        assertThat(mdcFilter.getUrlPatterns()).containsExactly("/test-override/*");
+    }
+
+    @TestConfiguration
+    static class OverrideTestConfig {
+        @Bean
+        FilterRegistrationBean<HttpHeaderNestedDiagnosticContextFilter> httpHeaderNestedDiagnosticContextFilter() {
+            HttpHeaderNestedDiagnosticContextFilter overriddenFilter = new HttpHeaderNestedDiagnosticContextFilter();
+
+            FilterRegistrationBean<HttpHeaderNestedDiagnosticContextFilter> registrationBean =
+                    new FilterRegistrationBean<>();
+            registrationBean.setFilter(overriddenFilter);
+            registrationBean.addUrlPatterns("/test-override/*");
+            return registrationBean;
+        }
+    }
+
+}


### PR DESCRIPTION
* feat: ISY-650 add @ConditionalOnMissingBean annotation to FilterRegistrationBean<HttpHeaderNestedDiagnosticContextFilter>
* chore: ISY-650 update changelog