### PR TITLE
[Sprint 93] ISY-658 (IF 2.x): StelltLoggingKontextBereit setzt generierte Korrelations-ID nicht in AufrufKontextTo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - `IFS-1583`: [isy-persistence] `IsyPersistenceOracleAutoConfiguration` verwendet relaxed-binding für ConditionalOnProperty
 - [isy-sonderzeichen] Hinzufügen eines neuen Packages mit Transformatoren für die DIN Norm 91379
 - `IFS-2044`: [isyfact-products-bom] OpenCSV Versionsanhebung auf 5.7.1
+- `ISY-658`: [isy-serviceapi-core] Setzen generierter Korrelations-IDs in das AufrufKontextTo im StelltLoggingKontextBereitInterceptor
 
 # 2.4.4
 - `IFS-1997`: Fix CVE-2022-42889 durch Anhebung von 'commons-text' auf 1.10

--- a/isy-serviceapi-core/CHANGELOG.md
+++ b/isy-serviceapi-core/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.5.0
+- `ISY-658`: Setzen generierter Korrelations-IDs in das AufrufKontextTo im StelltLoggingKontextBereitInterceptor
+
 # 2.4.0
 - `IFS-668`: Zurücksetzung der KorrelationsId des AnrufKontextTo bei einem Invoke
 

--- a/isy-serviceapi-core/src/main/java/de/bund/bva/isyfact/serviceapi/core/aop/StelltLoggingKontextBereitInterceptor.java
+++ b/isy-serviceapi-core/src/main/java/de/bund/bva/isyfact/serviceapi/core/aop/StelltLoggingKontextBereitInterceptor.java
@@ -81,6 +81,15 @@ public class StelltLoggingKontextBereitInterceptor implements MethodInterceptor 
         try {
             LOG.debug("Setze Korrelations-ID: " + korrelationsId);
             MdcHelper.pushKorrelationsId(korrelationsId);
+            if (stelltLoggingKontextBereit == null || stelltLoggingKontextBereit.nutzeAufrufKontext()) {
+                Optional<AufrufKontextTo> aufrufKontextToOptional =
+                        aufrufKontextToResolver.leseAufrufKontextTo(invocation.getArguments());
+                aufrufKontextToOptional.ifPresent(aufrufKontextTo -> {
+                    if (aufrufKontextTo.getKorrelationsId() == null || aufrufKontextTo.getKorrelationsId().isEmpty()) {
+                        aufrufKontextTo.setKorrelationsId(korrelationsId);
+                    }
+                });
+            }
             return invocation.proceed();
         } finally {
             // remove correlation id from MDC after service call

--- a/isy-serviceapi-core/src/test/java/de/bund/bva/isyfact/serviceapi/core/aop/StelltLoggingKontextBereitAspectTest.java
+++ b/isy-serviceapi-core/src/test/java/de/bund/bva/isyfact/serviceapi/core/aop/StelltLoggingKontextBereitAspectTest.java
@@ -100,6 +100,9 @@ public class StelltLoggingKontextBereitAspectTest {
         assertNotNull(service.getKorrelationsIDLetzterAufruf());
         //assert MDC state after call
         assertNull(MdcHelper.liesKorrelationsId());
+
+        // assert that generated correlation id was added to AufrufKontextTo
+        assertEquals(service.getKorrelationsIDLetzterAufruf(), to.getKorrelationsId());
     }
 
     @Test
@@ -119,6 +122,9 @@ public class StelltLoggingKontextBereitAspectTest {
         assertFalse(korrId.isEmpty());
         //assert MDC state after call
         assertNull(MdcHelper.liesKorrelationsId());
+
+        // assert that generated correlation id was added to AufrufKontextTo
+        assertEquals(service.getKorrelationsIDLetzterAufruf(), to.getKorrelationsId());
     }
 
     @Test

--- a/isy-serviceapi-core/src/test/java/de/bund/bva/isyfact/serviceapi/core/aop/StelltLoggingKontextBereitTest.java
+++ b/isy-serviceapi-core/src/test/java/de/bund/bva/isyfact/serviceapi/core/aop/StelltLoggingKontextBereitTest.java
@@ -64,6 +64,31 @@ public class StelltLoggingKontextBereitTest {
         assertNotNull(korrelationsId);
     }
 
+    @Test
+    public void testStelltLoggingKontextBereitMitAufrufKontextNichtErwartet() {
+        String korrelationsId =
+                this.dummyService.stelltLoggingKontextBereitMitAufrufKontextNichtErwartet(this.aufrufKontext);
+        // do not use correlation id of AufrufKontextTo and do not add it to AufrufKontextTo after creation
+        assertNotEquals(korrelationsId, this.aufrufKontext.getKorrelationsId());
+        assertNotNull(korrelationsId);
+    }
+
+    @Test
+    public void testStelltLoggingKontextBereitMitAufrufKontextErwartetKeineKorrelationsId() {
+        this.aufrufKontext.setKorrelationsId(null);
+        String korrelationsId = this.dummyService.stelltLoggingKontextBereitMitAufrufKontext(this.aufrufKontext);
+        // newly created correlation id is added to AufrufKontextTo
+        assertEquals(korrelationsId, this.aufrufKontext.getKorrelationsId());
+    }
+
+    @Test
+    public void testStelltLoggingKontextBereitMitAufrufKontextErwartetLeereKorrelationsId() {
+        this.aufrufKontext.setKorrelationsId("");
+        String korrelationsId = this.dummyService.stelltLoggingKontextBereitMitAufrufKontext(aufrufKontext);
+        // newly created correlation id is added to AufrufKontextTo
+        assertEquals(korrelationsId, this.aufrufKontext.getKorrelationsId());
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testStelltLoggingKontextBereitOhneAufrufKontextNichtErwartet() {
         this.dummyService.stelltLoggingKontextBereitOhneAufrufKontextNichtErwartet();

--- a/isy-serviceapi-core/src/test/java/de/bund/bva/isyfact/serviceapi/core/aop/StelltLoggingKontextBereitTest.java
+++ b/isy-serviceapi-core/src/test/java/de/bund/bva/isyfact/serviceapi/core/aop/StelltLoggingKontextBereitTest.java
@@ -84,7 +84,7 @@ public class StelltLoggingKontextBereitTest {
     @Test
     public void testStelltLoggingKontextBereitMitAufrufKontextErwartetLeereKorrelationsId() {
         this.aufrufKontext.setKorrelationsId("");
-        String korrelationsId = this.dummyService.stelltLoggingKontextBereitMitAufrufKontext(aufrufKontext);
+        String korrelationsId = this.dummyService.stelltLoggingKontextBereitMitAufrufKontext(this.aufrufKontext);
         // newly created correlation id is added to AufrufKontextTo
         assertEquals(korrelationsId, this.aufrufKontext.getKorrelationsId());
     }

--- a/isy-serviceapi-core/src/test/java/de/bund/bva/isyfact/serviceapi/core/aop/service/httpinvoker/v1_0_0/DummyKontextServiceImpl.java
+++ b/isy-serviceapi-core/src/test/java/de/bund/bva/isyfact/serviceapi/core/aop/service/httpinvoker/v1_0_0/DummyKontextServiceImpl.java
@@ -43,6 +43,12 @@ public class DummyKontextServiceImpl implements DummyKontextServiceRemoteBean {
     }
 
     @Override
+    @StelltLoggingKontextBereit(nutzeAufrufKontext = false)
+    public String stelltLoggingKontextBereitMitAufrufKontextNichtErwartet(AufrufKontextTo aufrufKontextTo) {
+        return MdcHelper.liesKorrelationsId();
+    }
+
+    @Override
     @StelltLoggingKontextBereit
     public String stelltLoggingKontextBereitOhneAufrufKontextNichtErwartet() {
         return MdcHelper.liesKorrelationsId();

--- a/isy-serviceapi-core/src/test/java/de/bund/bva/isyfact/serviceapi/core/aop/service/httpinvoker/v1_0_0/DummyKontextServiceRemoteBean.java
+++ b/isy-serviceapi-core/src/test/java/de/bund/bva/isyfact/serviceapi/core/aop/service/httpinvoker/v1_0_0/DummyKontextServiceRemoteBean.java
@@ -19,7 +19,7 @@ package de.bund.bva.isyfact.serviceapi.core.aop.service.httpinvoker.v1_0_0;
 import de.bund.bva.isyfact.serviceapi.service.httpinvoker.v1_0_0.AufrufKontextTo;
 
 /**
- * RemoteBean-Interface des Dummy-Services
+ * RemoteBean-Interface des Dummy-Services.
  */
 public interface DummyKontextServiceRemoteBean {
 
@@ -28,6 +28,8 @@ public interface DummyKontextServiceRemoteBean {
     public String stelltLoggingKontextNichtBereitMitAufrufKontext(AufrufKontextTo aufrufKontextTo);
 
     public String stelltLoggingKontextBereitOhneAufrufKontextErwartet();
+
+    public String stelltLoggingKontextBereitMitAufrufKontextNichtErwartet(AufrufKontextTo aufrufKontextTo);
 
     public String stelltLoggingKontextBereitOhneAufrufKontextNichtErwartet();
 

--- a/isy-serviceapi-core/src/test/java/de/bund/bva/isyfact/serviceapi/core/aop/test/LoggingKontextAspectService.java
+++ b/isy-serviceapi-core/src/test/java/de/bund/bva/isyfact/serviceapi/core/aop/test/LoggingKontextAspectService.java
@@ -40,7 +40,7 @@ public class LoggingKontextAspectService {
         throw new Exception();
     }
 
-    public void saveKorrelationsID(){
+    public void saveKorrelationsID() {
         this.korrelationsIDLetzterAufruf = MdcHelper.liesKorrelationsId();
     }
 


### PR DESCRIPTION
* feat: ISY-658 add generated correlation id to AufrufKontextTo in StelltLoggingKontextBereitInterceptor
* test: ISY-658 adjust tests for StelltLoggingKontextBereitInterceptor
* chore: ISY-658 update changelog