### PR TITLE
ISY-538: Behebung von Security Issues in isyfact-standards/release/2.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ hs_err_pid*
 
 # Ignore Maven-specific files
 target/
+
+# Ignore OS generated files
+.DS_Store

--- a/isy-batchrahmen/src/main/java/de/bund/bva/isyfact/batchrahmen/test/BatchProtokollTester.java
+++ b/isy-batchrahmen/src/main/java/de/bund/bva/isyfact/batchrahmen/test/BatchProtokollTester.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -57,11 +58,13 @@ public class BatchProtokollTester {
      *            Das zu überprüfende Batchprotokoll.
      */
     public BatchProtokollTester(String ergebnisDatei) {
-        DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
-        docFactory.setNamespaceAware(true);
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        factory.setNamespaceAware(true);
         DocumentBuilder builder;
         try {
-            builder = docFactory.newDocumentBuilder();
+            builder = factory.newDocumentBuilder();
             batchProtokoll = builder.parse(ergebnisDatei);
 
             XPathFactory xpathFactory = XPathFactory.newInstance();
@@ -72,7 +75,7 @@ public class BatchProtokollTester {
     }
 
     /**
-     * Überprüft ob das Batchprotokoll mindestens eine Meldung mit der angegebenen ID enthält.
+     * Überprüft, ob das Batchprotokoll mindestens eine Meldung mit der angegebenen ID enthält.
      * @param id
      *            Die gesucht MeldungsID
      * @return true/false

--- a/isy-batchrahmen/src/main/java/de/bund/bva/isyfact/batchrahmen/test/BatchProtokollTester.java
+++ b/isy-batchrahmen/src/main/java/de/bund/bva/isyfact/batchrahmen/test/BatchProtokollTester.java
@@ -32,6 +32,8 @@ import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.NodeList;
@@ -45,7 +47,7 @@ import org.xml.sax.SAXException;
  * 
  */
 public class BatchProtokollTester {
-
+    Logger logger = LoggerFactory.getLogger(BatchProtokollTester.class);
     /** Das BatchProtokoll Document. **/
     private Document batchProtokoll;
 
@@ -58,24 +60,24 @@ public class BatchProtokollTester {
      *            Das zu überprüfende Batchprotokoll.
      */
     public BatchProtokollTester(String ergebnisDatei) {
-        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
-        factory.setNamespaceAware(true);
+        DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+        docFactory.setNamespaceAware(true);
         DocumentBuilder builder;
         try {
-            builder = factory.newDocumentBuilder();
+            docFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            docFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            builder = docFactory.newDocumentBuilder();
             batchProtokoll = builder.parse(ergebnisDatei);
 
             XPathFactory xpathFactory = XPathFactory.newInstance();
             xpath = xpathFactory.newXPath();
         } catch (ParserConfigurationException | SAXException | IOException e) {
-            e.printStackTrace();
+            logger.error("Error while creating BatchProtokollTester", e);
         }
     }
 
     /**
-     * Überprüft, ob das Batchprotokoll mindestens eine Meldung mit der angegebenen ID enthält.
+     * Überprüft ob das Batchprotokoll mindestens eine Meldung mit der angegebenen ID enthält.
      * @param id
      *            Die gesucht MeldungsID
      * @return true/false
@@ -127,8 +129,8 @@ public class BatchProtokollTester {
     public Collection<String> getFehlerIds() {
         ArrayList<String> fehlerListe = new ArrayList<>();
         String xpathQuery = "//Meldung[@Typ='F']";
-        if (getNodeListFromXpath(xpathQuery).getLength() != 0) {
-            NodeList nodes = getNodeListFromXpath(xpathQuery);
+        NodeList nodes = getNodeListFromXpath(xpathQuery);
+        if (nodes.getLength() != 0) {
             for (int i = 0; i < nodes.getLength(); i++) {
                 NamedNodeMap attributMap = nodes.item(i).getAttributes();
                 fehlerListe.add(attributMap.getNamedItem("ID").getNodeValue());

--- a/isy-batchrahmen/src/main/java/de/bund/bva/isyfact/batchrahmen/test/BatchProtokollTester.java
+++ b/isy-batchrahmen/src/main/java/de/bund/bva/isyfact/batchrahmen/test/BatchProtokollTester.java
@@ -129,8 +129,8 @@ public class BatchProtokollTester {
     public Collection<String> getFehlerIds() {
         ArrayList<String> fehlerListe = new ArrayList<>();
         String xpathQuery = "//Meldung[@Typ='F']";
-        NodeList nodes = getNodeListFromXpath(xpathQuery);
-        if (nodes.getLength() != 0) {
+        if (getNodeListFromXpath(xpathQuery).getLength() != 0) {
+            NodeList nodes = getNodeListFromXpath(xpathQuery);
             for (int i = 0; i < nodes.getLength(); i++) {
                 NamedNodeMap attributMap = nodes.item(i).getAttributes();
                 fehlerListe.add(attributMap.getNamedItem("ID").getNodeValue());
@@ -144,13 +144,7 @@ public class BatchProtokollTester {
      * @return Menge der eindeutigen FehlerIDs
      */
     public Set<String> getFehlerIdsEindeutig() {
-        HashSet<String> fehlerIdsEindeutig = new HashSet<>();
-        for (String fehlerId : getFehlerIds()) {
-            if (!fehlerIdsEindeutig.contains(fehlerId)) {
-                fehlerIdsEindeutig.add(fehlerId);
-            }
-        }
-        return fehlerIdsEindeutig;
+        return new HashSet<>(getFehlerIds());
     }
 
     /**

--- a/isy-batchrahmen/src/main/java/de/bund/bva/isyfact/batchrahmen/test/BatchProtokollTester.java
+++ b/isy-batchrahmen/src/main/java/de/bund/bva/isyfact/batchrahmen/test/BatchProtokollTester.java
@@ -221,21 +221,4 @@ public class BatchProtokollTester {
             throw new RuntimeException(e);
         }
     }
-
-    /**
-     * Liefert das Feld 'xpath' zurück.
-     * @return Wert von xpath
-     */
-    public XPath getXpath() {
-        return xpath;
-    }
-
-    /**
-     * Setzt das Feld 'xpath'.
-     * @param xpath
-     *            Neuer Wert für xpath
-     */
-    public void setXpath(XPath xpath) {
-        this.xpath = xpath;
-    }
 }

--- a/isy-batchrahmen/src/test/java/de/bund/bva/isyfact/batchrahmen/test/BatchProtokollTesterTest.java
+++ b/isy-batchrahmen/src/test/java/de/bund/bva/isyfact/batchrahmen/test/BatchProtokollTesterTest.java
@@ -1,10 +1,14 @@
 package de.bund.bva.isyfact.batchrahmen.test;
 
+import java.io.IOException;
 import java.util.Collection;
 
 import de.bund.bva.isyfact.batchrahmen.test.BatchProtokollTester;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.Assert.*;
 
@@ -85,5 +89,17 @@ public class BatchProtokollTesterTest {
     public void getStatistikwert() {
         assertEquals(10, batchProtokollTester.getStatistikwert("STATISTIK1"));
         assertEquals(-1, batchProtokollTester.getStatistikwert("NICHTVORHANDEN"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "//Meldung[@ID='ERROR1'",  // Unclosed bracket
+            "//book[nonexistentFunction(@price)]",  // Nonexistent function
+            "//Meldung[@price=]"  // Wrong attribute usage
+    })
+    public void testInvalidXPaths(String invalidXPath) {
+        Assertions.assertThrows(RuntimeException.class, () -> {
+            batchProtokollTester.getNodeListFromXpath(invalidXPath);
+        });
     }
 }

--- a/isy-batchrahmen/src/test/java/de/bund/bva/isyfact/batchrahmen/test/BatchProtokollTesterTest.java
+++ b/isy-batchrahmen/src/test/java/de/bund/bva/isyfact/batchrahmen/test/BatchProtokollTesterTest.java
@@ -1,16 +1,14 @@
 package de.bund.bva.isyfact.batchrahmen.test;
 
-import java.io.IOException;
+import java.io.FileNotFoundException;
 import java.util.Collection;
 
-import de.bund.bva.isyfact.batchrahmen.test.BatchProtokollTester;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class BatchProtokollTesterTest {
 
@@ -94,11 +92,11 @@ public class BatchProtokollTesterTest {
     @ParameterizedTest
     @ValueSource(strings = {
             "//Meldung[@ID='ERROR1'",  // Unclosed bracket
-            "//book[nonexistentFunction(@price)]",  // Nonexistent function
-            "//Meldung[@price=]"  // Wrong attribute usage
+            "//Book[nonexistentFunction(@Price)]",  // Nonexistent function
+            "//Meldung[Price=]"  // Wrong attribute usage
     })
-    public void testInvalidXPaths(String invalidXPath) {
-        Assertions.assertThrows(RuntimeException.class, () -> {
+    void testInvalidXPaths(String invalidXPath) {
+        assertThrows(RuntimeException.class, () -> {
             batchProtokollTester.getNodeListFromXpath(invalidXPath);
         });
     }

--- a/isy-sicherheit/src/main/java/de/bund/bva/isyfact/sicherheit/impl/XmlAccess.java
+++ b/isy-sicherheit/src/main/java/de/bund/bva/isyfact/sicherheit/impl/XmlAccess.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -115,10 +116,12 @@ public class XmlAccess {
     public RollenRechteMapping parseRollenRechteFile(String filename) {
         LOG.debug("Lese Rollen-Rechte-Mapping aus {}.", filename);
         Document dom;
-        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
         InputStream stream = XmlAccess.class.getResourceAsStream(filename);
         try {
-            DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+            DocumentBuilder documentBuilder = factory.newDocumentBuilder();
             dom = documentBuilder.parse(stream);
             RollenRechteMapping result = parseDocument(dom);
             result.setAlleDefiniertenRechte(this.rechtIdZuRecht.values());

--- a/isy-sicherheit/src/main/java/de/bund/bva/isyfact/sicherheit/impl/XmlAccess.java
+++ b/isy-sicherheit/src/main/java/de/bund/bva/isyfact/sicherheit/impl/XmlAccess.java
@@ -116,12 +116,12 @@ public class XmlAccess {
     public RollenRechteMapping parseRollenRechteFile(String filename) {
         LOG.debug("Lese Rollen-Rechte-Mapping aus {}.", filename);
         Document dom;
-        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
-        InputStream stream = XmlAccess.class.getResourceAsStream(filename);
-        try {
-            DocumentBuilder documentBuilder = factory.newDocumentBuilder();
+        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        documentBuilderFactory.setExpandEntityReferences(false);
+        try (InputStream stream = XmlAccess.class.getResourceAsStream(filename)) {
+            documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
             dom = documentBuilder.parse(stream);
             RollenRechteMapping result = parseDocument(dom);
             result.setAlleDefiniertenRechte(this.rechtIdZuRecht.values());
@@ -138,16 +138,6 @@ public class XmlAccess {
             throw new RollenRechteMappingException(
                 SicherheitFehlerSchluessel.MSG_AUTORISIERUNG_ROLLENRECHTEMAPPING_FEHLERHAFT, ioe,
                 "IO-Exception");
-        } finally {
-            if (stream != null) {
-                try {
-                    stream.close();
-                } catch (IOException e) {
-                    throw new RollenRechteMappingException(
-                        SicherheitFehlerSchluessel.MSG_AUTORISIERUNG_ROLLENRECHTEMAPPING_FEHLERHAFT, e,
-                        "IO-Exception");
-                }
-            }
         }
     }
 

--- a/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/common/konstanten/EreignisSchluessel.java
+++ b/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/common/konstanten/EreignisSchluessel.java
@@ -21,6 +21,7 @@ package de.bund.bva.isyfact.ueberwachung.common.konstanten;
  */
 public class EreignisSchluessel {
 
+    private EreignisSchluessel() {}
     /** Standard-Ereignis für Debug/Info-Ausgaben ohne eigene Ereignis-ID. */
     public static final String PLUEB00001 = "PLUEB00001";
 
@@ -38,6 +39,9 @@ public class EreignisSchluessel {
      * Wird nicht mehr verwendet. */
     @Deprecated
     public static final String PLUEB00004 = "PLUEB00004";
+
+    /** Loadbalancer wurde abgefragt, aber isAlive-Datei existiert, aber es konnte keine Antwort gesendet werden */
+    public static final String IS_ALIVE_EXISTIERT_IO_EXCEPTION = "PLUEB00006";
 
     /** Loadbalancer wurde abgefragt, aber isAlive-Datei existiert nicht. */
     public static final String IS_ALIVE_EXISTIERT_NICHT = "PLUEB00005";

--- a/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/common/konstanten/EreignisSchluessel.java
+++ b/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/common/konstanten/EreignisSchluessel.java
@@ -26,17 +26,17 @@ public class EreignisSchluessel {
     public static final String PLUEB00001 = "PLUEB00001";
 
     /** Pruefung der Pruefroutine nicht erfolgreich.
-     * Wird nicht mehr verwendet. */
+     *  @deprecated  nicht mehr verwendet. */
     @Deprecated
     public static final String PLUEB00002 = "PLUEB00002";
 
     /** Pruefung der Pruefroutine nicht erfolgreich (hat Exception geworfen).
-     * Wird nicht mehr verwendet. */
+     * @deprecated Wird nicht mehr verwendet. */
     @Deprecated
     public static final String PLUEB00003 = "PLUEB00003";
 
     /** Selbsttest fehlgeschlagen.
-     * Wird nicht mehr verwendet. */
+     * @deprecated Wird nicht mehr verwendet. */
     @Deprecated
     public static final String PLUEB00004 = "PLUEB00004";
 

--- a/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/service/loadbalancer/LoadbalancerServlet.java
+++ b/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/service/loadbalancer/LoadbalancerServlet.java
@@ -89,22 +89,22 @@ public class LoadbalancerServlet extends HttpServlet {
      */
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
-        try {
-            if (isAliveFile.exists()) {
-                LOG.debug("IsAlive-Datei gefunden, sende HTTP OK.");
-                resp.setStatus(HttpServletResponse.SC_OK);
+        if (isAliveFile.exists()) {
+            LOG.debug("IsAlive-Datei gefunden, sende HTTP OK.");
+            resp.setStatus(HttpServletResponse.SC_OK);
+            try {
                 resp.getWriter().write("<html><body><center>IS ALIVE!</center></body></html>");
-            } else {
-                LOG.error(EreignisSchluessel.IS_ALIVE_EXISTIERT_NICHT,
-                        "IsAlive-Datei {} existiert nicht, sende HTTP FORBIDDEN.",
-                        isAliveFile.getAbsolutePath());
-                resp.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            } catch (IOException e) {
+                LOG.error(
+                        EreignisSchluessel.IS_ALIVE_EXISTIERT_IO_EXCEPTION,
+                        "IsyAlive-Datei {} existiert, fehler bei schreiben der Antwort in output-stream", isAliveFile.getAbsolutePath());
+                resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             }
-        } catch (IOException e) {
-            LOG.error(EreignisSchluessel.IS_ALIVE_EXISTIERT_IO_EXCEPTION,
-                    "IsyAlive-Datei {} existiert, Fehler beim Schreiben der Antwort in Output-Stream",
-                    e);
-            resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        } else {
+            LOG.error(
+                    EreignisSchluessel.IS_ALIVE_EXISTIERT_NICHT,
+                "IsAlive-Datei {} existiert nicht, sende HTTP FORBIDDEN.", isAliveFile.getAbsolutePath());
+            resp.setStatus(HttpServletResponse.SC_FORBIDDEN);
         }
     }
 }

--- a/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/service/loadbalancer/LoadbalancerServlet.java
+++ b/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/service/loadbalancer/LoadbalancerServlet.java
@@ -88,16 +88,23 @@ public class LoadbalancerServlet extends HttpServlet {
      *             Wenn die Antwort nicht geschrieben werden kann.
      */
     @Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-        if (isAliveFile.exists()) {
-            LOG.debug("IsAlive-Datei gefunden, sende HTTP OK.");
-            resp.setStatus(HttpServletResponse.SC_OK);
-            resp.getWriter().write("<html><body><center>IS ALIVE!</center></body></html>");
-        } else {
-            LOG.error(
-                    EreignisSchluessel.IS_ALIVE_EXISTIERT_NICHT,
-                "IsAlive-Datei {} existiert nicht, sende HTTP FORBIDDEN.", isAliveFile.getAbsolutePath());
-            resp.setStatus(HttpServletResponse.SC_FORBIDDEN);
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
+        try {
+            if (isAliveFile.exists()) {
+                LOG.debug("IsAlive-Datei gefunden, sende HTTP OK.");
+                resp.setStatus(HttpServletResponse.SC_OK);
+                resp.getWriter().write("<html><body><center>IS ALIVE!</center></body></html>");
+            } else {
+                LOG.error(EreignisSchluessel.IS_ALIVE_EXISTIERT_NICHT,
+                        "IsAlive-Datei {} existiert nicht, sende HTTP FORBIDDEN.",
+                        isAliveFile.getAbsolutePath());
+                resp.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            }
+        } catch (IOException e) {
+            LOG.error(EreignisSchluessel.IS_ALIVE_EXISTIERT_IO_EXCEPTION,
+                    "IsyAlive-Datei {} existiert, Fehler beim Schreiben der Antwort in Output-Stream",
+                    e);
+            resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/isy-ueberwachung/src/test/java/de/bund/bva/isyfact/ueberwachung/service/loadbalancer/TestLoadbalancerServlet.java
+++ b/isy-ueberwachung/src/test/java/de/bund/bva/isyfact/ueberwachung/service/loadbalancer/TestLoadbalancerServlet.java
@@ -107,9 +107,9 @@ public class TestLoadbalancerServlet {
 
 	@Test
 	public void testDoGetIOException() throws ServletException, IOException {
-		when(mockContext.getRealPath("/src/test/resources")).thenReturn("/src/test/resources/isAlive");
+		when(mockContext.getRealPath("/src/test/resources")).thenReturn("src/test/resources/isAlive");
 		when(mockConfig.getInitParameter("isAliveFileLocation")).thenReturn("/src/test/resources");
-		File f = new File("/src/test/resources/isAlive");
+		File f = new File("src/test/resources/isAlive");
 		assertTrue(f.createNewFile());
 		HttpServletResponse resp = mock(HttpServletResponse.class);
 		when(resp.getWriter()).thenThrow(new IOException("Simulated IOException"));

--- a/isy-ueberwachung/src/test/java/de/bund/bva/isyfact/ueberwachung/service/loadbalancer/TestLoadbalancerServlet.java
+++ b/isy-ueberwachung/src/test/java/de/bund/bva/isyfact/ueberwachung/service/loadbalancer/TestLoadbalancerServlet.java
@@ -105,4 +105,18 @@ public class TestLoadbalancerServlet {
 		f.delete();
 	}
 
+	@Test
+	public void testDoGetIOException() throws ServletException, IOException {
+		when(mockContext.getRealPath("/src/test/resources")).thenReturn("/src/test/resources/isAlive");
+		when(mockConfig.getInitParameter("isAliveFileLocation")).thenReturn("/src/test/resources");
+		File f = new File("/src/test/resources/isAlive");
+		assertTrue(f.createNewFile());
+		HttpServletResponse resp = mock(HttpServletResponse.class);
+		when(resp.getWriter()).thenThrow(new IOException("Simulated IOException"));
+		loadBalancer.init(mockConfig);
+		loadBalancer.doGet(null, resp);
+		verify(resp, times(1)).setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+
+		f.delete();
+	}
 }

--- a/isy-ueberwachung/src/test/java/de/bund/bva/isyfact/ueberwachung/service/loadbalancer/TestLoadbalancerServlet.java
+++ b/isy-ueberwachung/src/test/java/de/bund/bva/isyfact/ueberwachung/service/loadbalancer/TestLoadbalancerServlet.java
@@ -77,7 +77,7 @@ public class TestLoadbalancerServlet {
 	
 	
 	@Test
-	public void testDoGet() throws ServletException, IOException {
+	public void testDoGet() throws ServletException {
 		when(mockContext.getRealPath("/src/test/resources")).thenReturn("/src/test/resources/isAlive");
 		when(mockConfig.getInitParameter("isAliveFileLocation")).thenReturn("/src/test/resources");
 		loadBalancer.init(mockConfig);	


### PR DESCRIPTION
Fix 3 securities issues suggested by Sonarcloud by: 
- Disable access to external entities in XML parsing
- Handle the exception that could be thrown by "getWriter": IOException
