### PR TITLE
docs: ISY-951 clarify how to use entities at the business layer (3.x)

### DIFF
--- a/isyfact-standards-doc/src/docs/antora/modules/blaupausen/pages/detailkonzept-komponente-datenzugriff/changelog.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/blaupausen/pages/detailkonzept-komponente-datenzugriff/changelog.adoc
@@ -5,6 +5,7 @@
 
 // tag::release-3.0.0[]
 * `IFS-821`: Detailkonzept Datenzugriff aufgeteilt. Hibernate-spezifische Teile sind in einen eigenen Baustein "JPA/Hibernate" ausgelagert worden.
+* `IFS-1796`: Entfernung der Vorgabe zur Implementierung der Embeddable Annotation
 // end::release-3.0.0[]
 
 // *Änderungen IsyFact 2.4.0*

--- a/isyfact-standards-doc/src/docs/antora/modules/blaupausen/pages/detailkonzept-komponente-datenzugriff/persistenzlogik.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/blaupausen/pages/detailkonzept-komponente-datenzugriff/persistenzlogik.adoc
@@ -82,10 +82,3 @@ Idealerweise sollten die Entitäten lediglich Getter- und Setter-Methoden für d
 Jegliche Fachlogik muss im Anwendungskern implementiert werden.
 
 Zur Fachlogik gehören auch Validierungen.
-
-[[embeddables-vorgaben]]
-=== Vorgaben für `@Embeddable`-Entitäten
-
-Für JPA-Entitäten mit der Annotation `@Embeddable` müssen die Methoden `equals` und `hashCode` implementiert werden.
-Die Methoden müssen dafür sämtliche Attribute mit einbeziehen.
-Zusätzlich muss das Interface `Serializable` implementiert werden.

--- a/isyfact-standards-doc/src/docs/antora/modules/blaupausen/pages/referenzarchitektur-it-system/changelog.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/blaupausen/pages/referenzarchitektur-it-system/changelog.adoc
@@ -1,10 +1,10 @@
 [[changelog]]
 = Changelog
 
-// *Änderungen IsyFact 3.0.0*
+*Änderungen IsyFact 3.0.0*
 
 // tag::release-3.0.0[]
-
+- `IFS-1796`: Änderung der Architekturregel zur weitergabe von Entitäten
 // end::release-3.0.0[]
 
 *Änderungen IsyFact 2.4.0*

--- a/isyfact-standards-doc/src/docs/antora/modules/blaupausen/pages/referenzarchitektur-it-system/changelog.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/blaupausen/pages/referenzarchitektur-it-system/changelog.adoc
@@ -4,7 +4,7 @@
 *Änderungen IsyFact 3.0.0*
 
 // tag::release-3.0.0[]
-- `IFS-1796`: Änderung der Architekturregel zur weitergabe von Entitäten
+- `IFS-1796`: Änderung der Architekturregel zur Weitergabe von Entitäten
 // end::release-3.0.0[]
 
 *Änderungen IsyFact 2.4.0*

--- a/isyfact-standards-doc/src/docs/antora/modules/blaupausen/pages/referenzarchitektur-it-system/inhalt.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/blaupausen/pages/referenzarchitektur-it-system/inhalt.adoc
@@ -126,24 +126,18 @@ Weitere Details können dem xref:detailkonzept-komponente-anwendungskern/master.
 === Datenzugriff
 
 In der Persistenz-Schicht sind die Fachkomponenten auch gemäß den Komponenten aus der fachlichen Architektur strukturiert.
-Die Komponenten des Anwendungskerns besitzen die Datenhoheit auf Objekte, die ihnen eindeutig zuzuordnen sind.
-Diese Objekte stammen aus den korrespondierenden Komponenten in der Persistenz-Schicht.
-Nur die korrespondierende Anwendungskern-Komponente darf Änderungen an den entsprechenden persistenten Objekten vornehmen.
-Die persistenten Objekte dürfen nicht über Komponentengrenzen hinweg herausgegeben werden.
-In diesem Fall wäre nicht sichergestellt, dass keine Änderungen außerhalb der Komponente passieren.
-Für den Transfer über Komponentengrenzen hinweg müssen eigene, nicht-persistente Schnittstellen-Objekte erzeugt werden, die dann aus den persistenten Objekten mittels eines Bean-Mappers befüllt werden können. +
-Wenn Objekte von mehreren Komponenten genutzt werden und keiner einzelnen Komponente zugeordnet werden können, sollten sie in einem eigenen querschnittlichen Package abgelegt werden.
+Die Komponenten des Anwendungskerns besitzen die Datenhoheit auf die Entitäten, die ihnen eindeutig zuzuordnen sind.
+Diese Entitäten stammen aus den korrespondierenden Komponenten in der Persistenz-Schicht.
+Nur die korrespondierende Anwendungskern-Komponente darf Änderungen an den entsprechenden persistenten Entitäten vornehmen.
 
-Vereinfachend können Anwendungskern-Komponenten persistente Daten an die xref:glossary:glossary:master.adoc#glossar-service[Service]-Schicht (s. Kapitel <<servicezugriffe>>) weitergeben.
-Dies ist insbesondere dann angebracht, wenn die Komponente ausschließlich durch eine Service-Komponente genutzt wird. +
-Da die Service-Schicht keine Logik enthält und daher ohnehin keine Änderung an solchen Entitäten vornehmen darf und eindeutig der Anwendungskern-Komponente zugeordnet ist, bedeutet dies keine Verletzung der Datenhoheit.
-Da die Anwendungskern-Komponente an Ihrer Schnittstelle nun potenziell persistente und nicht persistente Entitäten bereitstellt, müssen Verwechselungen vermieden werden, z.B. indem solche Methoden in getrennten Interfaces deklariert werden.
-
-.icon:university[title=Architekturregel] Architekturregel
+.icon:university[title=Architekturregel] Persistente Entitäten im Anwendungskern
 ****
 Persistente Entitäten dürfen nicht über den Anwendungskern hinaus herausgegeben werden. Sie haben im Anwendungskern zu verbleiben.
 ****
 
+Andernfalls ist nicht sichergestellt, dass andere Komponente keine Änderungen an den persistenten Entitäten vornehmen.
+Für den Transfer über Komponentengrenzen hinweg - oder aus dem Anwendungskern hinaus - müssen alle Komponenten des Anwendungskerns die ihnen zugeordneten persistenten Entitäten auf Geschäftsobjekte abbilden.
+Wenn Entitäten von mehreren Komponenten genutzt werden und keiner einzelnen Komponente zugeordnet werden können, sollten sie in einem eigenen querschnittlichen Package abgelegt werden.
 
 [[gui]]
 === GUI

--- a/isyfact-standards-doc/src/docs/antora/modules/blaupausen/pages/referenzarchitektur-it-system/inhalt.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/blaupausen/pages/referenzarchitektur-it-system/inhalt.adoc
@@ -135,7 +135,7 @@ Nur die korrespondierende Anwendungskern-Komponente darf Änderungen an den ents
 Persistente Entitäten dürfen nicht über den Anwendungskern hinaus herausgegeben werden. Sie haben im Anwendungskern zu verbleiben.
 ****
 
-Andernfalls ist nicht sichergestellt, dass andere Komponente keine Änderungen an den persistenten Entitäten vornehmen.
+Andernfalls ist nicht sichergestellt, dass andere Komponenten keine Änderungen an den persistenten Entitäten vornehmen.
 Für den Transfer über Komponentengrenzen hinweg - oder aus dem Anwendungskern hinaus - müssen alle Komponenten des Anwendungskerns die ihnen zugeordneten persistenten Entitäten auf Geschäftsobjekte abbilden.
 Wenn Entitäten von mehreren Komponenten genutzt werden und keiner einzelnen Komponente zugeordnet werden können, sollten sie in einem eigenen querschnittlichen Package abgelegt werden.
 

--- a/isyfact-standards-doc/src/docs/antora/modules/changelog/pages/releasenotes.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/changelog/pages/releasenotes.adoc
@@ -58,6 +58,17 @@ Ausblick:: Die konzeptionelle Integration erfolgt in einem nachfolgenden Release
 === Optimierung Dependency Management
 Abhängigkeiten wurden überprüft und reduziert.
 
+
+[[kapitel-referenzarchitektur]]
+== Referenzarchitektur
+
+=== Software-technische Sicht
+Datenzugriff:: Für die Überführung von persistenten Entitäten in Geschäftsobjekte sollen keine gesonderten Schnittstellenobjekte mehr genutzt werden.
+Die Komponente Datenzugriff übergibt persistente Entitäten an den Anwendungskern.
+Der Anwendungskern darf keine persistenten Entitäten mehr herausgeben, auch nicht zwischen seinen Fachkomponenten.
+Entsprechende Ausnahmen wurden gestrichen.
+
+
 [[kapitel-bausteine]]
 == Isyfact Bausteine
 

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-persistence/pages/changelog.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-persistence/pages/changelog.adoc
@@ -1,8 +1,8 @@
 [[changelog]]
 = Changelog
 
-// *Änderungen IsyFact 3.0.0*
+*Änderungen IsyFact 3.0.0*
 
 // tag::release-3.0.0[]
-
+* `IFS-1797`: Vorgaben zu Hibernate Annotationen LazyToOne und LazyCollections entfernt
 // end::release-3.0.0[]

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-persistence/pages/konzept/vorgaben-konventionen.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-persistence/pages/konzept/vorgaben-konventionen.adoc
@@ -73,8 +73,6 @@ Standardmäßig verwendet Hibernate:
 Standardmäßig soll für alle Assoziationen Lazy Loading verwendet werden.
 Bytecode-Manipulationen für Lazy Loading sollen nicht verwendet werden.
 
-Die Verwendung der Annotationen `@LazyToOne` und `@LazyCollection` ist zu vermeiden, falls man nicht die Option `LazyCollectionOption.EXTRA` für extra große Collections benötigt.
-
 [[optimistic-locking]]
 === Optimistisches Locking standardmäßig verwenden
 

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-persistence/pages/nutzungsvorgaben/konfiguration.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-persistence/pages/nutzungsvorgaben/konfiguration.adoc
@@ -73,8 +73,6 @@ Hierfür ist das Attribute `fetch` der jeweiligen Mapping-Annotation wie folgt z
 @OneToMany(fetch = FetchType.EAGER)
 ----
 
-Die Verwendung der Annotationen `@LazyToOne` und `@LazyCollection` ist zu vermeiden, falls man nicht den `@LazyCollection` Wert „Extra“ für extra große Collections benötigt.
-
 [[standardmaessig-optimistisches-locking-verwenden]]
 === Standardmäßig optimistisches Locking verwenden
 


### PR DESCRIPTION
- remove requirements for deprecated Hibernate annotations
- remove requirements for embeddable entities