### PR TITLE
ISY-305 (3.x): Token-Util zum Auslesen aus dem Bearer Token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # 3.1.0
 - `ISY-808` isy-konfiguration als deprecated markiert
 - `ISY-948` : Spring Cache Abstraction als verpflichtende Bibliothek für anwendungsseitige Caches eingeführt
-- 
+- `ISY-305`: [isy-security] Implementierung von IsySecurityTokenUtil zum Auslesen von Attributen aus dem Bearer Token
+
 # 3.0.0
 - `ISY-653` : Erweitern des `TimeoutWiederholungHttpInvokerRequestExecutor` um die Token-Beschaffung aus dem Security Context bei Nichtverfügbarkeit des `AufrufKontextVerwalter`.
 - `ISY-183`: [isyfact-standards-doc] Migrationsleitfaden zur Entfernung der Bridge-Module

--- a/isy-security/CHANGELOG.md
+++ b/isy-security/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.1.0
+
+- `ISY-305`: Implementierung von IsySecurityTokenUtil zum Auslesen von Attributen aus dem Bearer Token
+
 # 3.0.0
 
 - `IFS-2561`: Die Konfiguration via `rollenrechte.xml` erfolgt optional. 

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/core/Berechtigungsmanager.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/core/Berechtigungsmanager.java
@@ -46,7 +46,9 @@ public interface Berechtigungsmanager {
      *
      * @param key the key to retrieve given attribute
      * @return the attribute in the access token for the given key, or {@code null}
+     * @deprecated this method is transferred to IsySecurityTokenUtil and will be removed from this interface in a future release
      */
+    @Deprecated
     @Nullable
     Object getTokenAttribute(String key);
 

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/core/Berechtigungsmanager.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/core/Berechtigungsmanager.java
@@ -5,6 +5,8 @@ import java.util.Set;
 import org.springframework.lang.Nullable;
 import org.springframework.security.access.AccessDeniedException;
 
+import de.bund.bva.isyfact.security.oauth2.util.IsySecurityTokenUtil;
+
 /**
  * Class for checking privileges in the currently authenticated principal manually if the capabilities provided
  * by Spring Security Method Security are not sufficient.
@@ -46,7 +48,7 @@ public interface Berechtigungsmanager {
      *
      * @param key the key to retrieve given attribute
      * @return the attribute in the access token for the given key, or {@code null}
-     * @deprecated this method is transferred to IsySecurityTokenUtil and will be removed from this interface in a future release
+     * @deprecated in favor of {@link IsySecurityTokenUtil#getTokenAttribute(String)}. This method will be removed in a future release.
      */
     @Deprecated
     @Nullable

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/core/IsyOAuth2Berechtigungsmanager.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/core/IsyOAuth2Berechtigungsmanager.java
@@ -13,6 +13,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.server.resource.authentication.AbstractOAuth2TokenAuthenticationToken;
 import org.springframework.util.Assert;
 
+import de.bund.bva.isyfact.security.oauth2.util.IsySecurityTokenUtil;
+
 /**
  * Default implementation of the {@link Berechtigungsmanager} that should suffice for most use cases.
  * <p>
@@ -21,7 +23,9 @@ import org.springframework.util.Assert;
  */
 public class IsyOAuth2Berechtigungsmanager implements Berechtigungsmanager {
 
-    /** The JWT claim name that contains the roles. */
+    /**
+     * The JWT claim name that contains the roles.
+     */
     private final String rolesClaimName;
 
     public IsyOAuth2Berechtigungsmanager(String rolesClaimName) {
@@ -29,7 +33,7 @@ public class IsyOAuth2Berechtigungsmanager implements Berechtigungsmanager {
     }
 
     public Set<String> getRollen() {
-        Object tokenRoles = getTokenAttribute(rolesClaimName);
+        Object tokenRoles = IsySecurityTokenUtil.getTokenAttribute(rolesClaimName);
         if (tokenRoles instanceof Collection) {
             return new HashSet<>((Collection<String>) tokenRoles);
         } else {
@@ -56,6 +60,7 @@ public class IsyOAuth2Berechtigungsmanager implements Berechtigungsmanager {
         }
     }
 
+    @Deprecated
     public Object getTokenAttribute(String key) {
         Authentication currentAuthentication = SecurityContextHolder.getContext().getAuthentication();
         if (currentAuthentication instanceof AbstractOAuth2TokenAuthenticationToken) {

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenUtil.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenUtil.java
@@ -1,0 +1,119 @@
+package de.bund.bva.isyfact.security.oauth2.util;
+
+import java.util.Optional;
+import java.util.ResourceBundle;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.oidc.StandardClaimNames;
+import org.springframework.security.oauth2.server.resource.authentication.AbstractOAuth2TokenAuthenticationToken;
+
+/**
+ * This class contains utility methods for isy-security. It provides access to the claims of the current OAuth 2.0 token.
+ */
+public class IsySecurityTokenUtil {
+
+
+    /**
+     * The resource bundle that contains the token configuration.
+     */
+    private static final ResourceBundle BUNDLE = ResourceBundle.getBundle("config.isy-security-token");
+
+    /**
+     * The JWT claim name that contains the login.
+     */
+    private static final String LOGIN = getString("login");
+
+    /**
+     * The JWT claim name that contains the userId.
+     */
+    private static final String USERID = getString("userId");
+
+    /**
+     * The JWT claim name that contains the bhknz (Behoerdenkennzeichen).
+     */
+    private static final String BHKNZ = getString("bhknz");
+    /**
+     * The JWT claim name that contains the display name.
+     */
+    private static final String DISPLAYNAME = getString("displayName");
+
+    /**
+     * The prefix for all configuration properties.
+     */
+    private static final String PREFIX = "isy.security.oauth2.claim.";
+
+    /**
+     * Returns the value of the configuration property with the given suffix.
+     *
+     * @param suffix the suffix of the configuration property
+     * @return the String value of the configuration property
+     */
+    private static String getString(String suffix) {
+        return BUNDLE.getString(PREFIX + suffix);
+    }
+
+    /**
+     * Returns the login of the current user or an empty Optional if the login attribute is not set.
+     *
+     * @return the login of the current user
+     */
+    public static Optional<String> getLogin() {
+        String login = (String) getTokenAttribute(LOGIN);
+        return Optional.ofNullable(login);
+    }
+
+    /**
+     * Returns the userId of the current user. If the userId is not set, the Subject identifier (sub) is returned.
+     *
+     * @return the userId of the current user or the Subject identifier (sub) if the userId is not set
+     */
+    public static String getUserId() {
+        String userId = (String) getTokenAttribute(USERID);
+        if (userId == null) {
+            return (String) getTokenAttribute(StandardClaimNames.SUB);
+        } else {
+            return userId;
+        }
+    }
+
+    /**
+     * Returns a bhknz of the current user or an empty Optional if the bhknz attribute is not set.
+     *
+     * @return the bhknz of the current user
+     */
+    public static Optional<String> getBhknz() {
+        String bhknz = (String) getTokenAttribute(BHKNZ);
+        return Optional.ofNullable(bhknz);
+    }
+
+    /**
+     * Returns the display name of the current user. If the display name is not set, the login is returned.
+     *
+     * @return the display name of the current user or the login if the display name is not set
+     */
+    public static Optional<String> getDisplayName() {
+        String displayName = (String) getTokenAttribute(DISPLAYNAME);
+        if (displayName == null) {
+            return getLogin();
+        }
+        return Optional.of(displayName);
+    }
+
+    /**
+     * Retrieves an attribute of the access token if the currently authenticated principal is an OAuth 2.0 token.
+     *
+     * @param key the key to retrieve the given attribute
+     * @return the attribute in the access token for the given key, or {@code null}
+     */
+    public static Object getTokenAttribute(String key) {
+        Authentication currentAuthentication = SecurityContextHolder.getContext().getAuthentication();
+        if (currentAuthentication instanceof AbstractOAuth2TokenAuthenticationToken) {
+            return ((AbstractOAuth2TokenAuthenticationToken<?>) currentAuthentication).getTokenAttributes().get(key);
+        } else {
+            throw new OAuth2AuthenticationException("Authentication is not an OAuth2 token authentication.");
+        }
+    }
+
+}

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenUtil.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenUtil.java
@@ -24,21 +24,21 @@ public class IsySecurityTokenUtil {
     /**
      * The JWT claim name that contains the login.
      */
-    private static final String LOGIN = getString("login");
+    private static final String LOGIN = getConfigPropertyValueAsString("login");
 
     /**
      * The JWT claim name that contains the userId.
      */
-    private static final String USERID = getString("userId");
+    private static final String USERID = getConfigPropertyValueAsString("userId");
 
     /**
      * The JWT claim name that contains the bhknz (Behoerdenkennzeichen).
      */
-    private static final String BHKNZ = getString("bhknz");
+    private static final String BHKNZ = getConfigPropertyValueAsString("bhknz");
     /**
      * The JWT claim name that contains the display name.
      */
-    private static final String DISPLAYNAME = getString("displayName");
+    private static final String DISPLAYNAME = getConfigPropertyValueAsString("displayName");
 
     /**
      * The prefix for all configuration properties.
@@ -51,7 +51,7 @@ public class IsySecurityTokenUtil {
      * @param suffix the suffix of the configuration property
      * @return the String value of the configuration property
      */
-    private static String getString(String suffix) {
+    private static String getConfigPropertyValueAsString(String suffix) {
         return BUNDLE.getString(PREFIX + suffix);
     }
 

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenUtil.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenUtil.java
@@ -7,6 +7,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.oidc.StandardClaimNames;
+import org.springframework.security.oauth2.server.resource.BearerTokenErrors;
 import org.springframework.security.oauth2.server.resource.authentication.AbstractOAuth2TokenAuthenticationToken;
 
 /**
@@ -104,15 +105,18 @@ public class IsySecurityTokenUtil {
     /**
      * Retrieves an attribute of the access token if the currently authenticated principal is an OAuth 2.0 token.
      *
-     * @param key the key to retrieve the given attribute
+     * @param key
+     *         the key to retrieve the given attribute
      * @return the attribute in the access token for the given key, or {@code null}
+     * @throws OAuth2AuthenticationException
+     *         if the authenticated principal is not a {@link AbstractOAuth2TokenAuthenticationToken}
      */
     public static Object getTokenAttribute(String key) {
         Authentication currentAuthentication = SecurityContextHolder.getContext().getAuthentication();
         if (currentAuthentication instanceof AbstractOAuth2TokenAuthenticationToken) {
             return ((AbstractOAuth2TokenAuthenticationToken<?>) currentAuthentication).getTokenAttributes().get(key);
         } else {
-            throw new OAuth2AuthenticationException("Authentication is not an OAuth2 token authentication.");
+            throw new OAuth2AuthenticationException(BearerTokenErrors.invalidToken("Authentication is not an OAuth2 token authentication."));
         }
     }
 

--- a/isy-security/src/main/resources/config/isy-security-token.properties
+++ b/isy-security/src/main/resources/config/isy-security-token.properties
@@ -1,0 +1,5 @@
+# Default settings for the OAuth2-Token claims
+isy.security.oauth2.claim.login=preferred_username
+isy.security.oauth2.claim.userId=internekennung
+isy.security.oauth2.claim.bhknz=bhknz
+isy.security.oauth2.claim.displayName=name

--- a/isy-security/src/test/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenUtilTest.java
+++ b/isy-security/src/test/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenUtilTest.java
@@ -1,0 +1,165 @@
+package de.bund.bva.isyfact.security.oauth2.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.oidc.StandardClaimNames;
+import org.springframework.security.oauth2.server.resource.authentication.AbstractOAuth2TokenAuthenticationToken;
+
+public class IsySecurityTokenUtilTest {
+
+
+    @BeforeEach
+    public void setUp() {
+        SecurityContextHolder.clearContext(); // Sicherstellen, dass der Kontext vor jedem Test zurückgesetzt wird
+    }
+
+    @Test
+    public void testGetUserId() {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put(StandardClaimNames.SUB, "test_sub");
+        attributes.put("internekennung", "test_userId");
+        mockSecurityContextWithTokenAttributes(attributes);
+
+        assertEquals("test_userId", IsySecurityTokenUtil.getUserId());
+    }
+
+    @Test
+    public void testGetUserIdWhenNull() {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("internekennung", null);
+        attributes.put(StandardClaimNames.SUB, "test_sub");
+        mockSecurityContextWithTokenAttributes(attributes);
+
+        assertEquals("test_sub", IsySecurityTokenUtil.getUserId());
+    }
+
+
+    @Test
+    public void testGetUserIdWhenEmpty() {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("internekennung", "");
+        mockSecurityContextWithTokenAttributes(attributes);
+
+        assertEquals("", IsySecurityTokenUtil.getUserId());
+    }
+
+    @Test
+    public void testGetLogin() {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("preferred_username", "test_login");
+        mockSecurityContextWithTokenAttributes(attributes);
+
+        assertTrue(IsySecurityTokenUtil.getLogin().isPresent());
+        assertEquals("test_login", IsySecurityTokenUtil.getLogin().get());
+    }
+
+    @Test
+    public void testGetLoginWhenEmpty() {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("preferred_username", "");
+        mockSecurityContextWithTokenAttributes(attributes);
+
+        Optional<String> optLogin = IsySecurityTokenUtil.getLogin();
+
+        assertTrue(optLogin.isPresent());
+        assertEquals("", optLogin.get());
+    }
+
+    @Test
+    public void testGetLoginWhenNull() {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("preferred_username", null);
+        mockSecurityContextWithTokenAttributes(attributes);
+
+        assertFalse(IsySecurityTokenUtil.getLogin().isPresent());
+    }
+
+    @Test
+    public void testGetBhknz() {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("bhknz", "test_bhknz");
+        mockSecurityContextWithTokenAttributes(attributes);
+
+        Optional<String> optBhknz = IsySecurityTokenUtil.getBhknz();
+
+        assertTrue(optBhknz.isPresent());
+        assertEquals("test_bhknz", optBhknz.get());
+    }
+
+    @Test
+    public void testGetBhknzWhenEmpty() {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("bhknz", "");
+        mockSecurityContextWithTokenAttributes(attributes);
+
+        Optional<String> optBhknz = IsySecurityTokenUtil.getBhknz();
+
+        assertTrue(optBhknz.isPresent());
+        assertEquals("", optBhknz.get());
+    }
+
+    @Test
+    public void testGetBhknzWhenNull() {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("bhknz", null);
+        mockSecurityContextWithTokenAttributes(attributes);
+
+        assertFalse(IsySecurityTokenUtil.getBhknz().isPresent());
+    }
+
+    @Test
+    public void testGetDisplayName() {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("name", "test_displayname");
+        mockSecurityContextWithTokenAttributes(attributes);
+
+        Optional<String> optDisplayName = IsySecurityTokenUtil.getDisplayName();
+
+        assertTrue(optDisplayName.isPresent());
+        assertEquals("test_displayname", optDisplayName.get());
+    }
+
+    @Test
+    public void testGetDisplayNameEmpty() {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("name", "");
+        mockSecurityContextWithTokenAttributes(attributes);
+
+        Optional<String> optDisplayName = IsySecurityTokenUtil.getDisplayName();
+
+        assertTrue(optDisplayName.isPresent());
+        assertEquals("", optDisplayName.get());
+    }
+
+    @Test
+    public void testGetDisplayNameNull() {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("name", null);
+        attributes.put("preferred_username", "test_login");
+        mockSecurityContextWithTokenAttributes(attributes);
+
+        Optional<String> optDisplayName = IsySecurityTokenUtil.getDisplayName();
+
+        assertTrue(optDisplayName.isPresent());
+        assertEquals("test_login", optDisplayName.get());
+    }
+
+    private void mockSecurityContextWithTokenAttributes(Map<String, Object> attributes) {
+        Map<String, Object> attrMap = new HashMap<>(attributes);
+        AbstractOAuth2TokenAuthenticationToken<?> authenticationToken = Mockito.mock(AbstractOAuth2TokenAuthenticationToken.class);
+        when(authenticationToken.getTokenAttributes()).thenReturn(Collections.unmodifiableMap(attrMap));
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+    }
+}

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/inhalt.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/inhalt.adoc
@@ -492,7 +492,7 @@ Die Autorisierung erfolgt dementsprechend wenn der Nutzer mindestens eins der in
 
 Bei der Befüllung des Spring Security Context wird das zur Befüllung genutzte Bearer Token ebenfalls im Context abgelegt.
 Dadurch ist der Zugriff auf Attribute des Bearer Tokens über den Spring Security Context möglich.
-Der Zugriff kann über den Berechtigungsmanager oder direkt über den Spring Security Context erfolgen.
+Der Zugriff kann über den Berechtigungsmanager, direkt über den Spring Security Context oder mithilfe der IsySecurityTokenUtil Klasse erfolgen.
 
 Für Zugriff über den Berechtigungsmanager kann die Methode `getTokenAttribute(String key)` genutzt werden.
 Das Beispiel <<listing-berechtigungsmanager-bhknz>> veranschaulicht den Zugriff auf das im Attribut `bhknz` gespeicherte Behördenkennzeichen.
@@ -503,9 +503,55 @@ Das Beispiel <<listing-berechtigungsmanager-bhknz>> veranschaulicht den Zugriff 
 ----
 String bhknz = (String) this.berechtigungsmanager.getTokenAttribute(BEARER_TOKEN_ATTR_BHKNZ);
 ----
+[NOTE]
+====
+Die Methode getTokenAttribute im Berechtigungsmanager ist deprecated und wird in zukünftigen Versionen entfernt.
+====
 
 Für den direkten Zugriff per Security Context kann die `Authentication` abgefragt und per Cast als ein `AbstractOAuth2TokenAuthenticationToken` zugegriffen werden.
 Detaillierte Informationen hierzu können der Spring Dokumentation entnommen werden.
+
+Die IsySecurityTokenUtil Klasse bietet statische Methoden zum Auslesen von Token-Claims:
+
+* getLogin()
+** Beschreibung: Gibt den Login des aktuellen Benutzers zurück.
+** Rückgabewert: Ein Optional<String>, das den Login des Benutzers enthält oder ein leeres Optional, wenn das Login-Attribut nicht gesetzt ist.
+
+* getUserId():
+** Beschreibung: Gibt die UserId des aktuellen Benutzers zurück.
+** Rückgabewert: Ein String, der die UserId oder, falls nicht gesetzt, den Subject Identifier (sub) enthält.
+
+* getBhknz():
+** Beschreibung: Gibt das Behördenkennzeichen (bhknz) des aktuellen Benutzers zurück.
+** Rückgabewert: Ein Optional<String>, das das Behördenkennzeichen enthält
+
+* getDisplayName():
+** Beschreibung: Gibt den Namen des aktuellen Benutzers zurück. Wenn der Name nicht gesetzt ist, wird der Login zurückgegeben.
+** Rückgabewert: Ein optionaler <String>, der den Namen oder, falls nicht gesetzt, den Login enthält.
+
+* getTokenAttribute(String key):
+** Beschreibung: Eine allgemeine Methode, um ein Attribut des Tokens abzurufen.
+** Rückgabewert: Das gesuchte Attribut des Tokens als Object. Sofern dieses nicht existiert, wird eine OAuth2AuthenticationException zurückgegeben.
+
+Beispiel zum Zugriff auf das Behördenkennzeichen mithilfe der IsySecurityTokenUtil Klasse:
+[[listing-IsySecurityTokenUtil-bhknz]]
+.Zugriff auf das Behördenkennzeichen über IsySecurityTokenUtil
+[source,java]
+----
+Optional<String> bhknz = IsySecurityTokenUtil.getBhknz();
+----
+IsySecurityTokenUtil ermöglicht es, Standard-Claims mithilfe von zusätzlichen Properties um benutzerdefinierte Claims zu erweitern. Die entsprechenden Property-Konfigurationen sind in der Datei "isy-security-token.properties" im Verzeichnis "resources/config" hinterlegt. Bei speziellen Anforderungen ist es möglich, die Datei anzupassen, um die Claims entsprechend zu modifizieren.
+
+[[table-parameter-service]]
+.Default Konfigurationsparameter der Claims
+[cols="3m,2m,2m",options="header"]
+|===
+|Parameter |Wertebereich |Default
+|isy.security.oauth2.claim.login | String | preferred_username
+|isy.security.oauth2.claim.userId | String | internekennung
+|isy.security.oauth2.claim.bhknz | String | bhknz
+|isy.security.oauth2.claim.displayName | String | name
+|===
 
 [[annotation-method-auth]]
 == Automatische Authentifizierung innerhalb von Methoden
@@ -537,7 +583,6 @@ void methodThatNeedsAuthentication() {
     ...
 }
 ----
-
 <1> Angabe der Client Registration ID ohne Verwendung von Attributnamen
 <2> Auflösung der Client Registration ID aus dem Wert der Property `test.auth.client-id`
 <3> Angabe der Client Registration ID mit dem Attributnamen `oauth2ClientRegistrationId`


### PR DESCRIPTION
* feat: ISY-305 create a token-util for reading attributes from the Bearer Token
* feat: ISY-305 mark getTokenAttribute in Berechtigungsmanager as deprecated

    change the internal logic of getTokenAttribute to make use of the token util

* test: ISY-305 create a UnitTest class for testing the token-util
* docs: ISY-305 add description for reading token claim using the IsySecurityTokenUtil
* chore: ISY-305 update changelogs
* fix: ISY-305 make sure `getRollen` in the berechtigungsmanager does not throw an exception
* refactor: ISY-305 improve internal API and javadoc