### PR TITLE
ISY-988: Analysis: Visibility of the document warnings

### DIFF
--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -8,8 +8,36 @@ on:
 jobs:
   TriggerBuild:
     runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ secrets.ANTORA_TRIGGER_TOKEN }}
     steps:
       - name: Trigger documentation build
-        run: gh workflow run antora_build.yml --repo IsyFact/isyfact.github.io --ref feature/ISY-998-Analyse_Sichtbarkeit_der_Doku_Warnungen
+        id: trigger_build
+        run: |
+          RESPONSE=$(gh workflow run antora_build.yml \
+            --repo IsyFact/isyfact.github.io \
+            --ref feature/ISY-998-Analyse_Sichtbarkeit_der_Doku_Warnungen \
+            --json)
+          echo "Response: $RESPONSE"
+          WORKFLOW_RUN_ID=$(echo "$RESPONSE" | jq '.id')
+          echo "Workflow run ID: $WORKFLOW_RUN_ID"
+          echo "WORKFLOW_RUN_ID=$WORKFLOW_RUN_ID" >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ secrets.ANTORA_TRIGGER_TOKEN }}
+
+      - name: Wait for workflow to complete
+        run: |
+          STATUS="queued"
+          while [[ "$STATUS" != "completed" ]]; do
+            sleep 10
+            RESULT=$(gh run view $WORKFLOW_RUN_ID --repo IsyFact/isyfact.github.io --json status,conclusion)
+            STATUS=$(echo "$RESULT" | jq -r '.status')
+            CONCLUSION=$(echo "$RESULT" | jq -r '.conclusion')
+            echo "Current status: $STATUS"
+          done
+          echo "Workflow conclusion: $CONCLUSION"
+          if [[ "$CONCLUSION" != "success" ]]; then
+            echo "::error::Workflow failed"
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.ANTORA_TRIGGER_TOKEN }}
+          WORKFLOW_RUN_ID: ${{ env.WORKFLOW_RUN_ID }}

--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -14,7 +14,7 @@ jobs:
         id: trigger_build
         with:
           token: ${{ secrets.ANTORA_TRIGGER_TOKEN }}
-          ref: feature/ISY-998-Analyse_Sichtbarkeit_der_Doku_Warnungen
+          ref: refs/heads/feature/ISY-998-Analyse_Sichtbarkeit_der_Doku_Warnungen
           repo: isyfact.github.io
           owner: IsyFact
           workflow: antora_build.yml

--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -10,34 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger documentation build
+        uses: codex-/return-dispatch@v1.12.0
         id: trigger_build
-        run: |
-          RESPONSE=$(gh workflow run antora_build.yml \
-            --repo IsyFact/isyfact.github.io \
-            --ref feature/ISY-998-Analyse_Sichtbarkeit_der_Doku_Warnungen \
-            --json)
-          echo "Response: $RESPONSE"
-          WORKFLOW_RUN_ID=$(echo "$RESPONSE" | jq '.id')
-          echo "Workflow run ID: $WORKFLOW_RUN_ID"
-          echo "WORKFLOW_RUN_ID=$WORKFLOW_RUN_ID" >> $GITHUB_ENV
-        env:
-          GH_TOKEN: ${{ secrets.ANTORA_TRIGGER_TOKEN }}
+        with:
+          token: ${{ secrets.ANTORA_TRIGGER_TOKEN }}
+          ref: feature/ISY-998-Analyse_Sichtbarkeit_der_Doku_Warnungen
+          repo: isyfact.github.io
+          owner: IsyFact
+          workflow: antora_build.yml
 
-      - name: Wait for workflow to complete
-        run: |
-          STATUS="queued"
-          while [[ "$STATUS" != "completed" ]]; do
-            sleep 10
-            RESULT=$(gh run view $WORKFLOW_RUN_ID --repo IsyFact/isyfact.github.io --json status,conclusion)
-            STATUS=$(echo "$RESULT" | jq -r '.status')
-            CONCLUSION=$(echo "$RESULT" | jq -r '.conclusion')
-            echo "Current status: $STATUS"
-          done
-          echo "Workflow conclusion: $CONCLUSION"
-          if [[ "$CONCLUSION" != "success" ]]; then
-            echo "::error::Workflow failed"
-            exit 1
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.ANTORA_TRIGGER_TOKEN }}
-          WORKFLOW_RUN_ID: ${{ env.WORKFLOW_RUN_ID }}
+      - name: Use the output run ID
+        run: echo ${{steps.trigger_build.outputs.run_id}}

--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -12,4 +12,4 @@ jobs:
       GH_TOKEN: ${{ secrets.ANTORA_TRIGGER_TOKEN }}
     steps:
       - name: Trigger documentation build
-        run: gh workflow run antora_build.yml -R IsyFact/isyfact.github.io
+        run: gh workflow run antora_build.yml --repo IsyFact/isyfact.github.io --ref feature/ISY-998-Analyse_Sichtbarkeit_der_Doku_Warnungen

--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -19,5 +19,12 @@ jobs:
           owner: IsyFact
           workflow: antora_build.yml
 
-      - name: Use the output run ID
-        run: echo ${{steps.trigger_build.outputs.run_id}}
+      - name: Await Run ID ${{ steps.trigger_build.outputs.run_id }}
+        uses: codex-/await-remote-run@v1.11.0
+        with:
+          token: ${{ secrets.ANTORA_TRIGGER_TOKEN }}
+          repo: isyfact.github.io
+          owner: IsyFact
+          run_id: ${{ steps.trigger_build.outputs.run_id }}
+          run_timeout_seconds: 300 # Optional
+          poll_interval_ms: 5000 # Optional

--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -1,8 +1,9 @@
 name: Build Documentation
 on:
   push:
-    tags:
-      - '\d+.\d+.\d+'
+#    tags:
+#      - '\d+.\d+.\d+'
+    branches: [feature/ISY-998-Analyse_Sichtbarkeit_der_Doku_Warnungen]
 
 jobs:
   TriggerBuild:

--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -1,9 +1,8 @@
 name: Build Documentation
 on:
   push:
-#    tags:
-#      - '\d+.\d+.\d+'
-    branches: [feature/ISY-998-Analyse_Sichtbarkeit_der_Doku_Warnungen]
+    tags:
+      - '\d+.\d+.\d+'
 
 jobs:
   TriggerBuild:
@@ -14,17 +13,17 @@ jobs:
         id: trigger_build
         with:
           token: ${{ secrets.ANTORA_TRIGGER_TOKEN }}
-          ref: refs/heads/feature/ISY-998-Analyse_Sichtbarkeit_der_Doku_Warnungen
+          ref: main
           repo: isyfact.github.io
           owner: IsyFact
           workflow: antora_build.yml
 
-      - name: Await Run ID ${{ steps.trigger_build.outputs.run_id }}
+      - name: Wait for documentation build completion (Run ID - ${{ steps.trigger_build.outputs.run_id }})
         uses: codex-/await-remote-run@v1.11.0
         with:
           token: ${{ secrets.ANTORA_TRIGGER_TOKEN }}
           repo: isyfact.github.io
           owner: IsyFact
           run_id: ${{ steps.trigger_build.outputs.run_id }}
-          run_timeout_seconds: 300 # Optional
-          poll_interval_ms: 5000 # Optional
+          run_timeout_seconds: 300 # 5 minutes (optional)
+          poll_interval_ms: 5000 # 5 seconds (optional)

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-datetime/pages/nutzungsvorgaben/thisdoc.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-datetime/pages/nutzungsvorgaben/thisdoc.adoc
@@ -18,7 +18,7 @@ Der Zweck dieses Dokuments ist Vorgaben zur Nutzung der _Java 8 Date and Time AP
 
 Das Dokument ist entsprechend dieser Zielsetzungen in die folgenden Kapitel untergliedert:
 
-Das Kapitel xref::nutzungsvorgaben/master.adoc#dauern-und-zeitzonen[*Dauern und Zeitzonen*] enthält grundlegende Informationen zum Umgang mit Dauern und Zeitzonen.
+Das Kapitel xref:nutzungsvorgaben/master.adoc#dauern-und-zeitzonen[*Dauern und Zeitzonen*] enthält grundlegende Informationen zum Umgang mit Dauern und Zeitzonen.
 
-Im Kapitel xref::nutzungsvorgaben/master.adoc#verwendung-der-bibliothek-isy-datetime[*Verwendung der Bibliothek*] wird der Inhalt und die Verwendung der Bibliothek `isy-datetime` beschrieben.
+Im Kapitel xref:nutzungsvorgaben/master.adoc#verwendung-der-bibliothek-isy-datetime[*Verwendung der Bibliothek*] wird der Inhalt und die Verwendung der Bibliothek `isy-datetime` beschrieben.
 // end::inhalt[]

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-exception-core/pages/konzept/thisdoc.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-exception-core/pages/konzept/thisdoc.adoc
@@ -12,7 +12,7 @@ Dieses Dokument enthält das technische Feinkonzept zur Fehlerbehandlung für al
 Die prinzipiellen Anforderungen bei der Verarbeitung von Exceptions und das Fehlerbehandlungskonzept werden beschrieben.
 Es werden hierbei die Anforderungen von Betrieb, Nutzern und Softwarelieferanten berücksichtigt.
 
-Ziel der im Kapitel xref::konzept/master.adoc#anforderungen-an-die-fehlerbehandlung[Anforderungen an die Fehlerbehandlung] beschriebenen Fehlerbehandlung ist:
+Ziel der im Kapitel xref:konzept/master.adoc#anforderungen-an-die-fehlerbehandlung[Anforderungen an die Fehlerbehandlung] beschriebenen Fehlerbehandlung ist:
 
 * das Erreichen eines effizienten und einheitlichen Umgangs mit Fehlern
 * die Gewährleistung der Wartbarkeit von Anwendungen durch aussagekräftige Fehler

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-exception-core/pages/nutzungsvorgaben/inhalt.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-exception-core/pages/nutzungsvorgaben/inhalt.adoc
@@ -150,7 +150,7 @@ Unchecked Exceptions sind nicht in den Methoden-Signaturen zu deklarieren, aber 
 Der folgende Abschnitt beschreibt das Werfen einer technischen checked Exception.
 Das Vorgehen wird nur für technische checked Exceptions beschrieben, da das Vorgehen für alle Arten von Exceptions gleich ist.
 
-Gemäß der Anforderungen aus xref::konzept/master.adoc#anforderungen-an-die-fehlerbehandlung[Anforderungen an die Fehlerbehandlung] sollte die Fehlerbehandlung übersichtlich sein.
+Gemäß der Anforderungen aus xref:konzept/master.adoc#anforderungen-an-die-fehlerbehandlung[Anforderungen an die Fehlerbehandlung] sollte die Fehlerbehandlung übersichtlich sein.
 Zur Sicherstellung der Übersichtlichkeit darf die Anzahl der verwendeten Exceptions die Anzahl möglicher Behandlungen nicht überschreiten.
 Es sollte also für jede mögliche Fehlerbehandlung auch nur eine Exception geworfen werden.
 Sofern sie nicht behandelbar sind, sind hierfür technische unchecked Exceptions zu verwenden.

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-exception-core/pages/nutzungsvorgaben/thisdoc.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-exception-core/pages/nutzungsvorgaben/thisdoc.adoc
@@ -14,6 +14,6 @@ Es enthält Vorgaben zur Nutzung der Isyfact-Fehlerbehandlung sowie zu deren Ums
 Die von den Anwendungen benötigten Exception-Klassen sind von der konkreten Anwendung abhängig und müssen im entsprechenden Projekt unter Berücksichtigung dieser Vorgaben erstellt werden.
 Zur Umsetzung werden ausführliche Beispiele gegeben.
 
-Im Kapitel xref::nutzungsvorgaben/master.adoc#implementierung-der-fehlerbehandlung[Implementierung der Fehlerbehandlung] werden die Nutzungsvorgaben definiert, wie Exceptions zu erstellen sind und wie sie behandelt werden müssen.
-Abschließend werden typische xref::nutzungsvorgaben/master.adoc#dos-und-donts[Dos and Don'ts] erläutert, die bei der Fehlerbehandlung beachtet werden müssen.
+Im Kapitel xref:nutzungsvorgaben/master.adoc#implementierung-der-fehlerbehandlung[Implementierung der Fehlerbehandlung] werden die Nutzungsvorgaben definiert, wie Exceptions zu erstellen sind und wie sie behandelt werden müssen.
+Abschließend werden typische xref:nutzungsvorgaben/master.adoc#dos-und-donts[Dos and Don'ts] erläutert, die bei der Fehlerbehandlung beachtet werden müssen.
 // end::inhalt[]

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-logging/pages/konzept/changelog.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-logging/pages/konzept/changelog.adoc
@@ -3,9 +3,9 @@
 
 *Änderungen IsyFact 4.0.0*
 
-tag::release-4.0.0[]
+// tag::release-4.0.0[]
 - `IFS-3663` Erwähnung PLIS aus Diagramm entfernt
-end::release-4.0.0[]
+// end::release-4.0.0[]
 
 // *Änderungen IsyFact 3.0.0*
 

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/konzept/inhalt.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/konzept/inhalt.adoc
@@ -429,7 +429,8 @@ Innerhalb der IsyFact werden bei der Autorisierung von Anwendungsaufrufen (von i
 [[resource-owner-password-credential-flow]]
 ===== Resource-Owner-Password-Credential Flow
 
-:linkaktuell: xref:client-credential-flow[]
+:linkaktuell: xref:isy-security:konzept/master.adoc#client-credential-flow[Client-Credential-Flow]
+
 include::glossary:miscellaneous:partial$deprecated-abschnitt.adoc[]
 
 ****
@@ -462,7 +463,7 @@ Das Access-Token enthält alle notwendigen Daten, um zu verifizieren, ob die auf
 
 
 [[client-credential-flow]]
-===== Client-Credential Flow
+===== Client-Credential-Flow
 
 Der _Client-Credential_-Flow wird und darf nur zur Berechtigungszuteilung eingesetzt werden, wenn die Client-Anwendung selbst auch der Besitzer der Authentifizierungsdaten und damit als Confidential-Client-Anwendung eingestuft ist.
 Dieser Credential-Flow ist nach SpringSecurity OAuth2.0 auch die einzige Möglichkeit einen technischen Nutzer (Client) zu authentifizieren.
@@ -470,7 +471,7 @@ Es erfolgt hierbei keine Interaktion durch einen Benutzer, der sein Passwort ein
 Die dabei verwendeten Authentifizierungsdaten `Client-ID` und `Client-Secret` müssen vor der Nutzung für die Client-Anwendung definiert und mit dem IAM-System abgestimmt sein.
 Die Verwaltung des Clients mit dem ihm zugeordneten Rollen erfolgt im IAM-System.
 
-.OAuth2.0 Client-Credential Flow
+.OAuth2.0 Client-Credential-Flow
 [id="image-clientcredential-flow",reftext="{figure-caption} {counter:figures}"]
 image::isy-security:konzept/Client-Credential-Flow.dn.svg[align="center"]
 
@@ -584,7 +585,7 @@ Als optional mögliche 2-Faktor-Authentifizierung ist im IAM-Service die Übermi
 Die Implementierung des IAM-Service muss für die 2-Faktor-Authentifizierung dieses Feature unterstützen, andernfalls wird das BHKNZ als optionales Attribut betrachtet.
 Wenn die IAM-Service-Implementierung dieses Feature unterstützt, dann wird ein mit den Authentifizierungsdaten gemeinsam übergebenes Behördenkennzeichen gegen das Behördenkennzeichen aus dem zu authentifizierenden Nutzerprofil geprüft.
 
-Wie in xref:konzept/master.adoc#aussensicht-der-komponente-security[Schnittstelle des Bausteins Security] beschrieben, wird bei den Authentifizierungsmethoden `authentifiziereClient()` und `authentifiziereSystem()` das Behördenkennzeichen als optionaler Parameter an den `Authentifizierungsmanager` übergeben, der es mit den anderen Authentifizierungsdaten zusammen an den IAM-Service weiterleitet.
+Wie in <<aussensicht-der-komponente-security,Schnittstelle des Bausteins Security>> beschrieben, wird bei den Authentifizierungsmethoden `authentifiziereClient()` und `authentifiziereSystem()` das Behördenkennzeichen als optionaler Parameter an den `Authentifizierungsmanager` übergeben, der es mit den anderen Authentifizierungsdaten zusammen an den IAM-Service weiterleitet.
 
 [[multiple-uris]]
 === Aufruf des IAM-Services über unterschiedliche URIs

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/inhalt.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/inhalt.adoc
@@ -9,7 +9,7 @@ Die Software-Architektur des Security-Bausteins bildet das Fundament für die Si
 Die korrekte Gestaltung und Implementierung dieser Architektur ist entscheidend, um Schutzmechanismen gegen potenzielle Sicherheitsbedrohungen zu etablieren.
 In diesem Kapitel wird detailliert auf die verschiedenen Aspekte der Software-Architektur des Security-Bausteins eingegangen und bewährte Methoden sowie bewährte Praktiken vorgestellt, um eine robuste und zuverlässige Sicherheitsinfrastruktur zu schaffen.
 
-Im Folgenden werden die xref:konzept/inhalt.adoc#aussensicht-der-komponente-security[Interfaces des Bausteins Security] genauer erläutert.
+Im Folgenden werden die xref:konzept/master.adoc#aussensicht-der-komponente-security [Interfaces des Bausteins Security] genauer erläutert.
 
 [[security-interface]]
 === Security
@@ -72,7 +72,7 @@ Zur Formulierung von Berechtigungsprüfungen stehen folgende Methoden des Berech
 
 NOTE: Primär sollte die Berechtigungsprüfung über die Spring Annotation `@Secured` und nicht über die hier erwähnte Methode `pruefeRecht(String recht)` erfolgen.
 
-[[aufrufen-von-nachbarsystemen]]
+[[aufrufen_von_nachbarsystemen]]
 == Aufrufen von Nachbarsystemen
 
 Der Aufruf von Nachbarsystemen erfolgt auf Basis des reaktiven `Spring WebClient`.
@@ -135,7 +135,6 @@ Das Präfix sämtlicher Konfigurationsparameter `spring.security.oauth2` wird zu
 
 [[isyfact-specific-client-registration]]
 ==== Isyfact spezifische Konfigurationsparameter
-
 
 :linkaktuell: xref:spring-oauth2-client-registration[Client-Credentials-Flow]
 include::glossary:miscellaneous:partial$deprecated-abschnitt.adoc[]

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-task/pages/nutzungsvorgaben.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-task/pages/nutzungsvorgaben.adoc
@@ -42,7 +42,7 @@ In diesem Fall ist die Dauer zwischen dem Ende der letzten Ausführung und dem B
 
 Diese exemplarische Option sollte verwendet werden, wenn es zwingend erforderlich ist, dass die vorherige Ausführung abgeschlossen ist, bevor sie erneut ausgeführt wird.
 
-Weitere Informationen über den Einsatz von Annotationsattributen finden sich in der https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/scheduling/annotation/Scheduled.html#dokumentation-spring[Spring Dokumentation].
+Weitere Informationen über den Einsatz von Annotationsattributen finden sich in der xref:https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/scheduling/annotation/Scheduled.html#dokumentation-spring[Spring Dokumentation].
 
 Damit eine `@Scheduled`-Annotation von Spring registriert wird, muss die Klasse, in welcher der Task erstellt wird, entweder mit `@Component` annotiert werden oder über eine @Bean-Methode in den Kontext gelegt werden.
 

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-task/pages/nutzungsvorgaben.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-task/pages/nutzungsvorgaben.adoc
@@ -42,7 +42,7 @@ In diesem Fall ist die Dauer zwischen dem Ende der letzten Ausführung und dem B
 
 Diese exemplarische Option sollte verwendet werden, wenn es zwingend erforderlich ist, dass die vorherige Ausführung abgeschlossen ist, bevor sie erneut ausgeführt wird.
 
-Weitere Informationen über den Einsatz von Annotationsattributen finden sich in der xref:https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/scheduling/annotation/Scheduled.html#dokumentation-spring[Spring Dokumentation].
+Weitere Informationen über den Einsatz von Annotationsattributen finden sich in der https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/scheduling/annotation/Scheduled.html#dokumentation-spring[Spring Dokumentation].
 
 Damit eine `@Scheduled`-Annotation von Spring registriert wird, muss die Klasse, in welcher der Task erstellt wird, entweder mit `@Component` annotiert werden oder über eine @Bean-Methode in den Kontext gelegt werden.
 


### PR DESCRIPTION
- Ticket info: https://tracker.seitenbau.net/browse/ISY-998
### Changes
- Trigger documentation build and wait for its completion
    - Use `return_dispatch` action to trigger the documentation build workflow in `isyfact.github.io` and get the run ID
    - Use `await_remote_run` to wait for the completion of the documentation build. This uses the run ID from `return_dispatch` to keep track of the run
        - If the documentation build succeeds, the run will complete ([Example](https://github.com/IsyFact/isyfact-standards/actions/runs/8250547312/job/22598441402))
        - If the documentation build fails, the run will fail ([Example](https://github.com/IsyFact/isyfact-standards/actions/runs/8230113550/job/22502687931))
            - Status of each step of the foreign run ist logged to see which exact steps fail
        - There is link to the foreign run
- Fix any invalid references in AsciiDoc files if possible to prevent warnings and errors