### PR TITLE
ISY-988: Analysis: Visibility of the document warnings (release/3.x)

### DIFF
--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -7,8 +7,23 @@ on:
 jobs:
   TriggerBuild:
     runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ secrets.ANTORA_TRIGGER_TOKEN }}
     steps:
       - name: Trigger documentation build
-        run: gh workflow run antora_build.yml -R IsyFact/isyfact.github.io
+        uses: codex-/return-dispatch@v1.12.0
+        id: trigger_build
+        with:
+          token: ${{ secrets.ANTORA_TRIGGER_TOKEN }}
+          ref: main
+          repo: isyfact.github.io
+          owner: IsyFact
+          workflow: antora_build.yml
+
+      - name: Wait for documentation build completion (Run ID - ${{ steps.trigger_build.outputs.run_id }})
+        uses: codex-/await-remote-run@v1.11.0
+        with:
+          token: ${{ secrets.ANTORA_TRIGGER_TOKEN }}
+          repo: isyfact.github.io
+          owner: IsyFact
+          run_id: ${{ steps.trigger_build.outputs.run_id }}
+          run_timeout_seconds: 300 # 5 minutes (optional)
+          poll_interval_ms: 5000 # 5 seconds (optional)

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-bedienkonzept/pages/bedienkonzept.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-bedienkonzept/pages/bedienkonzept.adoc
@@ -1091,7 +1091,7 @@ In diesem Kapitel werden Bedienelemente besprochen und allgemeine Eigenschaften 
 [[testbarkeit-bedienelemente]]
 *Testbarkeit der Bedienelemente*
 
-Um die Grundlage für automatische Tests (Einsatz von Testframeworks) von Bedienelementen einer Web-basierenden Anwendung zu schaffen, sollten allen Maskenobjekten im HTML-Sourcecode eindeutige IDs zugeordnet sein (s.a. Abschnitt: xref:Testbarkeit-von-Anwendungen[Testbarkeit von Web-basierenden Anwendungen]).
+Um die Grundlage für automatische Tests (Einsatz von Testframeworks) von Bedienelementen einer Web-basierenden Anwendung zu schaffen, sollten allen Maskenobjekten im HTML-Sourcecode eindeutige IDs zugeordnet sein (s.a. Abschnitt: xref:testbarkeit-von-anwendungen[Testbarkeit von Web-basierenden Anwendungen]).
 
 
 

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-bedienkonzept/pages/bedienkonzept.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-bedienkonzept/pages/bedienkonzept.adoc
@@ -2208,7 +2208,7 @@ Festlegungen auf höherer Ebene (z.B. der Anwendungslandschaft) gelten für alle
 
 Die IsyFact sieht grundsätzlich zwei Strukturierungen vor.
 
-[BEDIENKONZEPT]
+[example]
 ====
 Bei der fachlichen Spezifikation einer neuen Fachanwendung oder Anwendungslandschaft muss eine der folgenden Strukturierungen für die Navigation ausgewählt und fest vorgegeben werden:
 

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-datetime/pages/nutzungsvorgaben/thisdoc.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-datetime/pages/nutzungsvorgaben/thisdoc.adoc
@@ -18,7 +18,7 @@ Der Zweck dieses Dokuments ist Vorgaben zur Nutzung der _Java 8 Date and Time AP
 
 Das Dokument ist entsprechend dieser Zielsetzungen in die folgenden Kapitel untergliedert:
 
-Das Kapitel xref::nutzungsvorgaben/master.adoc#dauern-und-zeitzonen[*Dauern und Zeitzonen*] enthält grundlegende Informationen zum Umgang mit Dauern und Zeitzonen.
+Das Kapitel xref:nutzungsvorgaben/master.adoc#dauern-und-zeitzonen[*Dauern und Zeitzonen*] enthält grundlegende Informationen zum Umgang mit Dauern und Zeitzonen.
 
-Im Kapitel xref::nutzungsvorgaben/master.adoc#verwendung-der-bibliothek-isy-datetime[*Verwendung der Bibliothek*] wird der Inhalt und die Verwendung der Bibliothek `isy-datetime` beschrieben.
+Im Kapitel xref:nutzungsvorgaben/master.adoc#verwendung-der-bibliothek-isy-datetime[*Verwendung der Bibliothek*] wird der Inhalt und die Verwendung der Bibliothek `isy-datetime` beschrieben.
 // end::inhalt[]

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-exception-core/pages/konzept/thisdoc.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-exception-core/pages/konzept/thisdoc.adoc
@@ -12,7 +12,7 @@ Dieses Dokument enthält das technische Feinkonzept zur Fehlerbehandlung für al
 Die prinzipiellen Anforderungen bei der Verarbeitung von Exceptions und das Fehlerbehandlungskonzept werden beschrieben.
 Es werden hierbei die Anforderungen von Betrieb, Nutzern und Softwarelieferanten berücksichtigt.
 
-Ziel der im Kapitel xref::konzept/master.adoc#anforderungen-an-die-fehlerbehandlung[Anforderungen an die Fehlerbehandlung] beschriebenen Fehlerbehandlung ist:
+Ziel der im Kapitel xref:konzept/master.adoc#anforderungen-an-die-fehlerbehandlung[Anforderungen an die Fehlerbehandlung] beschriebenen Fehlerbehandlung ist:
 
 * das Erreichen eines effizienten und einheitlichen Umgangs mit Fehlern
 * die Gewährleistung der Wartbarkeit von Anwendungen durch aussagekräftige Fehler

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-exception-core/pages/nutzungsvorgaben/inhalt.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-exception-core/pages/nutzungsvorgaben/inhalt.adoc
@@ -150,7 +150,7 @@ Unchecked Exceptions sind nicht in den Methoden-Signaturen zu deklarieren, aber 
 Der folgende Abschnitt beschreibt das Werfen einer technischen checked Exception.
 Das Vorgehen wird nur für technische checked Exceptions beschrieben, da das Vorgehen für alle Arten von Exceptions gleich ist.
 
-Gemäß der Anforderungen aus xref::konzept/master.adoc#anforderungen-an-die-fehlerbehandlung[Anforderungen an die Fehlerbehandlung] sollte die Fehlerbehandlung übersichtlich sein.
+Gemäß der Anforderungen aus xref:konzept/master.adoc#anforderungen-an-die-fehlerbehandlung[Anforderungen an die Fehlerbehandlung] sollte die Fehlerbehandlung übersichtlich sein.
 Zur Sicherstellung der Übersichtlichkeit darf die Anzahl der verwendeten Exceptions die Anzahl möglicher Behandlungen nicht überschreiten.
 Es sollte also für jede mögliche Fehlerbehandlung auch nur eine Exception geworfen werden.
 Sofern sie nicht behandelbar sind, sind hierfür technische unchecked Exceptions zu verwenden.

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-exception-core/pages/nutzungsvorgaben/thisdoc.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-exception-core/pages/nutzungsvorgaben/thisdoc.adoc
@@ -14,6 +14,6 @@ Es enthält Vorgaben zur Nutzung der Isyfact-Fehlerbehandlung sowie zu deren Ums
 Die von den Anwendungen benötigten Exception-Klassen sind von der konkreten Anwendung abhängig und müssen im entsprechenden Projekt unter Berücksichtigung dieser Vorgaben erstellt werden.
 Zur Umsetzung werden ausführliche Beispiele gegeben.
 
-Im Kapitel xref::nutzungsvorgaben/master.adoc#implementierung-der-fehlerbehandlung[Implementierung der Fehlerbehandlung] werden die Nutzungsvorgaben definiert, wie Exceptions zu erstellen sind und wie sie behandelt werden müssen.
-Abschließend werden typische xref::nutzungsvorgaben/master.adoc#dos-und-donts[Dos and Don'ts] erläutert, die bei der Fehlerbehandlung beachtet werden müssen.
+Im Kapitel xref:nutzungsvorgaben/master.adoc#implementierung-der-fehlerbehandlung[Implementierung der Fehlerbehandlung] werden die Nutzungsvorgaben definiert, wie Exceptions zu erstellen sind und wie sie behandelt werden müssen.
+Abschließend werden typische xref:nutzungsvorgaben/master.adoc#dos-und-donts[Dos and Don'ts] erläutert, die bei der Fehlerbehandlung beachtet werden müssen.
 // end::inhalt[]

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/konzept/inhalt.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/konzept/inhalt.adoc
@@ -483,7 +483,8 @@ Innerhalb der IsyFact werden bei der Autorisierung von Anwendungsaufrufen (von i
 [[resource-owner-password-credential-flow]]
 ===== Resource-Owner-Password-Credential Flow
 
-:linkaktuell: xref:client-credential-flow[]
+:linkaktuell: xref:isy-security:konzept/master.adoc#client-credential-flow[Client-Credential-Flow]
+
 include::glossary:miscellaneous:partial$deprecated-abschnitt.adoc[]
 
 ****
@@ -516,7 +517,7 @@ Das Access-Token enthält alle notwendigen Daten, um zu verifizieren, ob die auf
 
 
 [[client-credential-flow]]
-===== Client-Credential Flow
+===== Client-Credential-Flow
 
 Der _Client-Credential_-Flow wird und darf nur zur Berechtigungszuteilung eingesetzt werden, wenn die Client-Anwendung selbst auch der Besitzer der Authentifizierungsdaten und damit als Confidential-Client-Anwendung eingestuft ist.
 Dieser Credential-Flow ist nach SpringSecurity OAuth2.0 auch die einzige Möglichkeit einen technischen Nutzer (Client) zu authentifizieren.
@@ -524,7 +525,7 @@ Es erfolgt hierbei keine Interaktion durch einen Benutzer, der sein Passwort ein
 Die dabei verwendeten Authentifizierungsdaten `Client-ID` und `Client-Secret` müssen vor der Nutzung für die Client-Anwendung definiert und mit dem IAM-System abgestimmt sein.
 Die Verwaltung des Clients mit dem ihm zugeordneten Rollen erfolgt im IAM-System.
 
-.OAuth2.0 Client-Credential Flow
+.OAuth2.0 Client-Credential-Flow
 [id="image-clientcredential-flow",reftext="{figure-caption} {counter:figures}"]
 image::isy-security:konzept/Client-Credential-Flow.dn.svg[align="center"]
 
@@ -638,7 +639,7 @@ Als optional mögliche 2-Faktor-Authentifizierung ist im IAM-Service die Übermi
 Die Implementierung des IAM-Service muss für die 2-Faktor-Authentifizierung dieses Feature unterstützen, andernfalls wird das BHKNZ als optionales Attribut betrachtet.
 Wenn die IAM-Service-Implementierung dieses Feature unterstützt, dann wird ein mit den Authentifizierungsdaten gemeinsam übergebenes Behördenkennzeichen gegen das Behördenkennzeichen aus dem zu authentifizierenden Nutzerprofil geprüft.
 
-Wie in xref:konzept/master.adoc#aussensicht-der-komponente-security[Schnittstelle des Bausteins Security] beschrieben, wird bei den Authentifizierungsmethoden `authentifiziereClient()` und `authentifiziereSystem()` das Behördenkennzeichen als optionaler Parameter an den `Authentifizierungsmanager` übergeben, der es mit den anderen Authentifizierungsdaten zusammen an den IAM-Service weiterleitet.
+Wie in <<aussensicht-der-komponente-security,Schnittstelle des Bausteins Security>> beschrieben, wird bei den Authentifizierungsmethoden `authentifiziereClient()` und `authentifiziereSystem()` das Behördenkennzeichen als optionaler Parameter an den `Authentifizierungsmanager` übergeben, der es mit den anderen Authentifizierungsdaten zusammen an den IAM-Service weiterleitet.
 
 [[rollen-und-rechte]]
 == Rollen & Rechte

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/inhalt.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/inhalt.adoc
@@ -384,7 +384,7 @@ Zusätzlich sind folgende Isyfact-spezifischen Konfigurationsparameter notwendig
 |isy.security.roles-claim-name | String | _roles_ | Name des Claims im JWT Token der die Rollen enthält
 |===
 
-[INFO]
+[NOTE]
 ====
 Der in `isy.security.roles-claim-name` konfigurierte Wert unterstützt keine Verschachtelungen. Somit kann bspw. ein Claim `custom.roles` (Claim `custom` mit untergeordnetem Claim `roles`) nicht aufgelöst werden. Je nach verwendetem Identity Provider muss ggf. ein zusätzliches Mapping der Rollen auf den konfigurierten Wert erfolgen.
 
@@ -549,7 +549,7 @@ Optional<String> bhknz = IsySecurityTokenUtil.getBhknz();
 ----
 IsySecurityTokenUtil ermöglicht es, Standard-Claims mithilfe von zusätzlichen Properties um benutzerdefinierte Claims zu erweitern. Die entsprechenden Property-Konfigurationen sind in der Datei "isy-security-token.properties" im Verzeichnis "resources/config" hinterlegt. Bei speziellen Anforderungen ist es möglich, die Datei anzupassen, um die Claims entsprechend zu modifizieren.
 
-[[table-parameter-service]]
+[[table-parameter-claims]]
 .Default Konfigurationsparameter der Claims
 [cols="3m,2m,2m",options="header"]
 |===

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/thisdoc.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/thisdoc.adoc
@@ -11,7 +11,7 @@ Der Baustein Security ist OAuth2.0 konform und greift hauptsächlich auf die Mö
 Die folgenden Kapitel leiten durch die Funktionen des Bausteins `isy-security`.
 
 * xref:nutzungsvorgaben/master.adoc#software-architektur-security-baustein[Software-Architektur des Security Bausteins]
-* xref:nutzungsvorgaben/master.adoc#aufrufen-von-nachbarsystemen[Aufrufen von Nachbarsystemen]
+* xref:nutzungsvorgaben/master.adoc#aufrufen_von_nachbarsystemen[Aufrufen von Nachbarsystemen]
 * xref:nutzungsvorgaben/master.adoc#auth_sgw[Authentifizierung über das SGW am IAM-Service]
 * xref:nutzungsvorgaben/master.adoc#absicherung_von_batches_tasks[Absicherung von Batches und Tasks]
 * xref:nutzungsvorgaben/master.adoc#absicherung_von_service_schnittstellen[Absicherung von Service-Schnittstellen]

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/thisdoc.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/thisdoc.adoc
@@ -11,7 +11,7 @@ Der Baustein Security ist OAuth2.0 konform und greift hauptsächlich auf die Mö
 Die folgenden Kapitel leiten durch die Funktionen des Bausteins `isy-security`.
 
 * xref:nutzungsvorgaben/master.adoc#software-architektur-security-baustein[Software-Architektur des Security Bausteins]
-* xref:nutzungsvorgaben/master.adoc#aufrufen_von_nachbarsystemen[Aufrufen von Nachbarsystemen]
+* xref:nutzungsvorgaben/inhalt.adoc#aufrufen-von-nachbarsystemen[Aufrufen von Nachbarsystemen]
 * xref:nutzungsvorgaben/master.adoc#auth_sgw[Authentifizierung über das SGW am IAM-Service]
 * xref:nutzungsvorgaben/master.adoc#absicherung_von_batches_tasks[Absicherung von Batches und Tasks]
 * xref:nutzungsvorgaben/master.adoc#absicherung_von_service_schnittstellen[Absicherung von Service-Schnittstellen]

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-serviceapi-core/pages/konzept/thisdoc.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-serviceapi-core/pages/konzept/thisdoc.adoc
@@ -21,8 +21,8 @@ Es sorgt dafür, dass Services in allen IT-Systemen gleichartig umgesetzt werden
 Das Dokument richtet sich vor allem an Software-Architekten und beschreibt, wie ein IT-System mit einer Service-Schnittstelle basierend auf HTTP Invoker versehen wird, oder solche Schnittstellen aufruft.
 Dabei vertieft es die Grundlagen, die im xref:blaupausen:detailkonzept-komponente-service/master.adoc[Detailkonzept Komponente Service] beschrieben werden und wendet sie auf das Service-Framework HTTP Invoker an.
 
-Das Dokument erläutert im Kapitel xref::konzept/master.adoc#kommunikation-mit-http-invoker[Kommunikation mit HTTP Invoker] zunächst die Grundlagen, Rahmenbedingungen und Beschränkungen des Einsatzes von HTTP Invoker.
-Danach beleuchtet das Kapitel xref::konzept/master.adoc#aufbau-der-servicelogik[Aufbau der Servicelogik], wie die Komponente Service architektonisch mit HTTP Invoker aufgebaut ist.
-Im Kapitel xref::konzept/master.adoc#auslieferung-einer-service-schnittstelle[Auslieferung einer Service-Schnittstelle] geht es darum, wie HTTP Invoker Schnittstellen ausgeliefert werden und was dabei zu beachten ist.
-Schließlich zeigt das Dokument noch Vorgaben zu den Themen xref::konzept/master.adoc#versionierung[Versionierung] und xref::konzept/master.adoc#namenskonventionen[Namenskonventionen] auf.
+Das Dokument erläutert im Kapitel xref:konzept/master.adoc#kommunikation-mit-http-invoker[Kommunikation mit HTTP Invoker] zunächst die Grundlagen, Rahmenbedingungen und Beschränkungen des Einsatzes von HTTP Invoker.
+Danach beleuchtet das Kapitel xref:konzept/master.adoc#aufbau-der-servicelogik[Aufbau der Servicelogik], wie die Komponente Service architektonisch mit HTTP Invoker aufgebaut ist.
+Im Kapitel xref:konzept/master.adoc#auslieferung-einer-service-schnittstelle[Auslieferung einer Service-Schnittstelle] geht es darum, wie HTTP Invoker Schnittstellen ausgeliefert werden und was dabei zu beachten ist.
+Schließlich zeigt das Dokument noch Vorgaben zu den Themen xref:konzept/master.adoc#versionierung[Versionierung] und xref:konzept/master.adoc#namenskonventionen[Namenskonventionen] auf.
 // end::inhalt[]

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-serviceapi-core/pages/nutzungsvorgaben/thisdoc.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-serviceapi-core/pages/nutzungsvorgaben/thisdoc.adoc
@@ -17,13 +17,13 @@ Das Dokument xref:konzept/master.adoc[KonzeptHttpInvoker] konzentriert sich auf 
 Dieses Dokument beschreibt, wie diese Services konkret umgesetzt werden.
 Es richtet sich an Entwickler, die ein xref:glossary:glossary:master.adoc#glossar-it-system[IT-System] gemäß den Vorgaben der IsyFact mit der Fähigkeit zur Kommunikation mit anderen IT-Systemen ausstatten müssen und beschreibt, was bei der Umsetzung zu bedenken ist.
 
-Dazu beschreibt das Kapitel xref::nutzungsvorgaben/master.adoc#maven-konfiguration[Maven-Konfiguration] zunächst die grundlegende Konfiguration, um den Baustein in ein IT-System einzubinden.
+Dazu beschreibt das Kapitel xref:nutzungsvorgaben/master.adoc#maven-konfiguration[Maven-Konfiguration] zunächst die grundlegende Konfiguration, um den Baustein in ein IT-System einzubinden.
 Danach beschreibt das Dokument die Realisierung eines Services in den Kapiteln:
 
-* xref::nutzungsvorgaben/master.adoc#realisierung-remote-bean[Realisierung des Remote-Beans],
-* xref::nutzungsvorgaben/master.adoc#realisierung-exception-fassade[Realisierung der Exception-Fassade],
-* xref::nutzungsvorgaben/master.adoc#realisierung-service-fassade[Realisierung der Service-Fassade],
-* xref::nutzungsvorgaben/master.adoc#realisierung-to[Realisierung von Transportobjekten].
+* xref:nutzungsvorgaben/master.adoc#realisierung-remote-bean[Realisierung des Remote-Beans],
+* xref:nutzungsvorgaben/master.adoc#realisierung-exception-fassade[Realisierung der Exception-Fassade],
+* xref:nutzungsvorgaben/master.adoc#realisierung-service-fassade[Realisierung der Service-Fassade],
+* xref:nutzungsvorgaben/master.adoc#realisierung-to[Realisierung von Transportobjekten].
 
-Danach geht es um die xref::nutzungsvorgaben/master.adoc#paketierung[Paketierung einer Service-Schnittstelle] und die xref::nutzungsvorgaben/master.adoc#nutzung[Nutzung einer Service-Schnittstelle] durch ein anderes IT-System.
+Danach geht es um die xref:nutzungsvorgaben/master.adoc#paketierung[Paketierung einer Service-Schnittstelle] und die xref:nutzungsvorgaben/master.adoc#nutzung[Nutzung einer Service-Schnittstelle] durch ein anderes IT-System.
 // end::inhalt[]

--- a/isyfact-standards-doc/src/docs/antora/modules/werkzeuge/pages/entwicklungsumgebung/thisdoc.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/werkzeuge/pages/entwicklungsumgebung/thisdoc.adoc
@@ -18,11 +18,11 @@ Die IsyFact liefert eine Konfiguration für _Checkstyle_ mit.
 
 Dieses Dokument beschreibt die Einrichtung und Verwendung dieser Funktionen wie folgt:
 
-Das Kapitel xref::entwicklungsumgebung/master.adoc#formatierung-von-quellcode[Formatierung von Quellcode] beschreibt die einheitliche Konfiguration und Verwendung der in Eclipse und IntelliJ IDEA eingebauten Code-Formatierer.
+Das Kapitel xref:entwicklungsumgebung/master.adoc#formatierung-von-quellcode[Formatierung von Quellcode] beschreibt die einheitliche Konfiguration und Verwendung der in Eclipse und IntelliJ IDEA eingebauten Code-Formatierer.
 Die Konfiguration hat zum Ziel, den Quellcode in beiden IDEs nahezu identisch formatiert zu formatieren.
 Das Kapitel schließt mit einer kurzen Diskussion der verbleibenden Unterschiede bei der Formatierung.
 
-Das Kapitel xref::entwicklungsumgebung/master.adoc#generierung-von-equals-und-hashcode[Generierung von equals() und hashCode()] beschreibt insbesondere die Generierung von `equals()` und `hashCode()` konform zu den xref:methodik:java-programmierkonventionen/master.adoc[Java Programmierkonventionen].
+Das Kapitel xref:entwicklungsumgebung/master.adoc#generierung-von-equals-und-hashcode[Generierung von equals() und hashCode()] beschreibt insbesondere die Generierung von `equals()` und `hashCode()` konform zu den xref:methodik:java-programmierkonventionen/master.adoc[Java Programmierkonventionen].
 
-Im Kapitel xref::entwicklungsumgebung/master.adoc#einrichtung-von-checkstyle[Einrichtung von Checkstyle] wird die Installation und Einrichtung der Checkstyle-Plugins für Eclipse und IntelliJ IDEA beschrieben.
+Im Kapitel xref:entwicklungsumgebung/master.adoc#einrichtung-von-checkstyle[Einrichtung von Checkstyle] wird die Installation und Einrichtung der Checkstyle-Plugins für Eclipse und IntelliJ IDEA beschrieben.
 // end::inhalt[]


### PR DESCRIPTION
- Ticket info: https://tracker.seitenbau.net/browse/ISY-998
### Changes
- Trigger documentation build and wait for its completion
    - Use `return_dispatch` action to trigger the documentation build workflow in `isyfact.github.io` and get the run ID
    - Use `await_remote_run` to wait for the completion of the documentation build. This uses the run ID from `return_dispatch` to keep track of the run
        - If the documentation build succeeds, the run will complete ([Example](https://github.com/IsyFact/isyfact-standards/actions/runs/8250547312/job/22598441402))
        - If the documentation build fails, the run will fail ([Example](https://github.com/IsyFact/isyfact-standards/actions/runs/8230113550/job/22502687931))
            - Status of each step of the foreign run ist logged to see which exact steps fail
        - There is link to the foreign run
- Fix any invalid references in AsciiDoc files if possible to prevent warnings and errors