### PR TITLE
[Sprint 100] ISY-980 (3.x): Security-Umstellung Dokumentation

### DIFF
--- a/isy-security/CHANGELOG.md
+++ b/isy-security/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 3.1.0
 
 - `ISY-305`: Implementierung von IsySecurityTokenUtil zum Auslesen von Attributen aus dem Bearer Token
+- `ISY-980`: Anpassung der Dokumentation aufgrund von Security-Umstellungen
 
 # 3.0.0
 

--- a/isyfact-standards-doc/src/docs/antora/modules/changelog/pages/migrationsleitfaden.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/changelog/pages/migrationsleitfaden.adoc
@@ -230,7 +230,13 @@ Eine Beschreibung der Parameter findet sich in den xref:isy-security:nutzungsvor
 <<table-sicherheit-konfiguration>> gibt eine Übersicht über die zu ändernden Parameter.
 Die `instances[n]` Notation aus den isy-sicherheit-keycloak Properties wird in isy-security nicht länger unterstützt.
 Jede Instanz soll durch eine sprechende und eindeutige `registration-id` ersetzt werden.
-Falls mehrere Instanzen für das gleiche Realm konfiguriert wurden, kann der `provider-name` pro Realm einmalig konfiguriert und für mehrer OAuth 2.0 Client Registrations (`registration-id`) wiederverwendet werden.
+Falls mehrere Instanzen für das gleiche Realm konfiguriert wurden, kann der `provider-name` pro Realm einmalig konfiguriert und für mehrere OAuth 2.0 Client Registrations (`registration-id`) wiederverwendet werden.
+
+[WARNING]
+====
+Falls Keycloak als Identity Provider verwendet wird, müssen für die Clients zusätzlich ein "Realm Role Mapper", der die Realm-Rollen in den in `isy.security.roles-claim-name` konfigurierten Claim schreibt (Default: `roles`), sowie ein "Audience Mapper",
+welcher das `aud`-Claim auf den Namen des verwendeten Clients setzt, konfiguriert werden.
+====
 
 Aus Platzgründen wurde in der ersten Spalte auf das `isy.sicherheit.keycloak` Präfix verzichtet.
 Analog wurde bei allen Properties der zweiten Spalte, die mit einem Punkt beginnen, auf das Präfix `spring.security.oauth2.client` verzichtet.

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/inhalt.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/inhalt.adoc
@@ -381,8 +381,15 @@ Zusätzlich sind folgende Isyfact-spezifischen Konfigurationsparameter notwendig
 [cols="3m,2m,2m,8",options="header"]
 |===
 |Parameter |Wertebereich |Default |Beschreibung
-|isy.security.rolesClaimName | String | _roles_ | Name des Claims im JWT Token der die Rollen enthält
+|isy.security.roles-claim-name | String | _roles_ | Name des Claims im JWT Token der die Rollen enthält
 |===
+
+[INFO]
+====
+Der in `isy.security.roles-claim-name` konfigurierte Wert unterstützt keine Verschachtelungen. Somit kann bspw. ein Claim `custom.roles` (Claim `custom` mit untergeordnetem Claim `roles`) nicht aufgelöst werden. Je nach verwendetem Identity Provider muss ggf. ein zusätzliches Mapping der Rollen auf den konfigurierten Wert erfolgen.
+
+Es ist sicherzustellen, dass das konfigurierte Roles-Claim auch vom Identity Provider befüllt werden.
+====
 
 [[konfiguration-von-rollen-und-rechten]]
 === Konfiguration von Rollen und Rechten


### PR DESCRIPTION
* docs: ISY-980 adjust description for roles property and add info about required mappers when Keycloak is provider
* chore: ISY-980 update changelog