### PR TITLE
[Sprint 100] ISY-1061 Nutzungsvorgaben REST Zurücksetzen der Korrelations ID beschreiben 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `ISY-651`: [isy-service-rest] Abschnitt zum Setzen von X-Correlation-Id in den HTTP-Header hinzugefügt
 - `ISY-546`: [isy-sicherheit] Abräumen des SecurityContexts im NutzerAuthentifizierungInterceptor
 - `ISY-650`: [isy-aufrufkontext] `FilterRegistrationBean<HttpHeaderNestedDiagnosticContextFilter>` überschreibbar
+- `ISY-1061`: [isyfact-standards-doc] Ergänzung der Dokumentation zum Zurücksetzen der Korrelations-ID aus dem MdcHelper
 
 # 2.4.4
 - `IFS-1997`: Fix CVE-2022-42889 durch Anhebung von 'commons-text' auf 1.10

--- a/isy-service-rest/src/docs/asciidoc/konzept/inhalt.adoc
+++ b/isy-service-rest/src/docs/asciidoc/konzept/inhalt.adoc
@@ -747,6 +747,10 @@ public WebClient webClient() {
 }
 ----
 
+Nachdem eine Anfrage bearbeitet wurde, sorgt der `HttpHeaderNestedDiagnosticContextFilter` im Rahmen seiner
+`afterRequest()`-Methode dafür, dass die Korrelations-ID aus dem MdcHelper entfernt wird. Dies erfolgt durch den Aufruf
+von `MdcHelper.entferneKorrelationsIds()`, der alle zuvor gesetzten Korrelations-IDs zurücksetzt.
+
 [[fehlerbehandlung]]
 === Fehlerbehandlung
 


### PR DESCRIPTION
* docs: ISY-1061 add explanation for deletion of correlationIDs
* chore: ISY-1061 update changelog