### PR TITLE
[Sprint 101] IFS-2248 Tokenerneuerung isy batchrahmen 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - `ISY-1040`: [isyfact-standards-doc] Anpassung des logback.xml-Konfigurationspfads im IF2-Migrationsleitfaden
 - `ISY-1061`: [isyfact-standards-doc] Ergänzung der Dokumentation zum Zurücksetzen der Korrelations-ID aus dem MdcHelper
 - `IFS-3665`: [isyfact-standards-doc] "Leitfaden Dokumentation" nach `isy-documentation` verschoben
+- `IFS-2248`: [isy-batchrahmen, isy-security] Tokenerneuerung in isy-batchrahmen:
+  * `IsySecurityTokenUtil` und `IsyOAuth2Authentifizierungsmanager` stellen Funktionalität zur Token-Gültigkeitsüberprüfung und erneuten Authentifizierung bereit
+  * Funktionalität zur erneuten Authentifizierung wird von `BatchrahmenImpl` aufgerufen
 
 # 3.0.1
 - `ISY-701`: Google Guava Versionsanhebung auf 33.1.0

--- a/isy-batchrahmen/CHANGELOG.md
+++ b/isy-batchrahmen/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.1.0
+- `IFS-2248`: Durchführen einer erneuten Authentifizierung bei Token-Ablauf in BatchrahmenImpl
+
 # 3.0.0
 - `IFS-1148`: Fehler wegen zu langem Klassenpfad unter Windows behoben
 - `IFS-1091`: Fehlerhafte ExcludeFromBatchContext-Annotation behoben

--- a/isy-batchrahmen/src/main/java/de/bund/bva/isyfact/batchrahmen/batch/konstanten/KonfigurationSchluessel.java
+++ b/isy-batchrahmen/src/main/java/de/bund/bva/isyfact/batchrahmen/batch/konstanten/KonfigurationSchluessel.java
@@ -80,6 +80,12 @@ public final class KonfigurationSchluessel {
      */
     public static final String PROPERTY_BATCH_OAUTH2_CLIENT_REGISTRATION_ID = "batch.oauth2ClientRegistrationId";
 
+    /**
+     * Property name for the time frame before expiry in seconds during which a token is considered as already expired
+     * before the actual token expiration.
+     */
+    public static final String PROPERTY_BATCH_OAUTH2_MINIMUM_TOKEN_VALIDITY = "batch.oauth2MinimumTokenValidity";
+
     /***************************************************************************
      * COMMAND LINE PARAMETERS *
      **************************************************************************/

--- a/isy-batchrahmen/src/main/java/de/bund/bva/isyfact/batchrahmen/core/rahmen/impl/BatchrahmenImpl.java
+++ b/isy-batchrahmen/src/main/java/de/bund/bva/isyfact/batchrahmen/core/rahmen/impl/BatchrahmenImpl.java
@@ -170,6 +170,12 @@ public class BatchrahmenImpl implements Batchrahmen, InitializingBean,
             long expirationOffsetSeconds = verarbInfo.getKonfiguration().getAsLong(
                     KonfigurationSchluessel.PROPERTY_BATCH_OAUTH2_MINIMUM_TOKEN_VALIDITY, DEFAULT_TOKEN_EXPIRATION_TIME_OFFSET);
 
+            if (expirationOffsetSeconds < 0) {
+                throw new BatchrahmenKonfigurationException(
+                        NachrichtenSchluessel.ERR_KONF_PARAMETER_UNGUELTIG, String.valueOf(expirationOffsetSeconds),
+                        KonfigurationSchluessel.PROPERTY_BATCH_OAUTH2_MINIMUM_TOKEN_VALIDITY);
+            }
+
             String oauth2ClientRegistrationId = null;
 
             try {

--- a/isy-batchrahmen/src/main/java/de/bund/bva/isyfact/batchrahmen/core/rahmen/impl/BatchrahmenImpl.java
+++ b/isy-batchrahmen/src/main/java/de/bund/bva/isyfact/batchrahmen/core/rahmen/impl/BatchrahmenImpl.java
@@ -58,8 +58,6 @@ import de.bund.bva.isyfact.security.oauth2.client.Authentifizierungsmanager;
 
 /**
  * Implementation of the 'Batchrahmen-Funktionalitaet'.
- *
- * @param <T> is the type of 'AufrufKontextes' to be used.
  */
 public class BatchrahmenImpl implements Batchrahmen, InitializingBean,
         ApplicationContextAware, DisposableBean {

--- a/isy-batchrahmen/src/test/java/de/bund/bva/isyfact/batchrahmen/BatchrahmenTestConfig.java
+++ b/isy-batchrahmen/src/test/java/de/bund/bva/isyfact/batchrahmen/BatchrahmenTestConfig.java
@@ -2,13 +2,11 @@ package de.bund.bva.isyfact.batchrahmen;
 
 import javax.annotation.Nullable;
 
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.PlatformTransactionManager;
 
+import de.bund.bva.isyfact.batchrahmen.batch.BasicAuthenticationTestBatch;
 import de.bund.bva.isyfact.batchrahmen.batch.BasicTestBatch;
 import de.bund.bva.isyfact.batchrahmen.batch.ErrorTestBatch;
 import de.bund.bva.isyfact.batchrahmen.batch.GesicherterTestBatch;
@@ -41,6 +39,11 @@ public class BatchrahmenTestConfig {
     @Bean
     public BasicTestBatch basicTestBatch() {
         return new BasicTestBatch();
+    }
+
+    @Bean
+    public BasicAuthenticationTestBatch basicAuthenticationTestBatch() {
+        return new BasicAuthenticationTestBatch();
     }
 
     @Bean

--- a/isy-batchrahmen/src/test/java/de/bund/bva/isyfact/batchrahmen/batch/BasicAuthenticationTestBatch.java
+++ b/isy-batchrahmen/src/test/java/de/bund/bva/isyfact/batchrahmen/batch/BasicAuthenticationTestBatch.java
@@ -1,0 +1,120 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * The Federal Office of Administration (Bundesverwaltungsamt, BVA)
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * License). You may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package de.bund.bva.isyfact.batchrahmen.batch;
+
+import java.util.Date;
+
+import de.bund.bva.isyfact.logging.IsyLogger;
+import de.bund.bva.isyfact.logging.IsyLoggerFactory;
+import de.bund.bva.isyfact.logging.LogKategorie;
+import de.bund.bva.isyfact.batchrahmen.batch.exception.BatchAusfuehrungsException;
+import de.bund.bva.isyfact.batchrahmen.batch.konfiguration.BatchKonfiguration;
+import de.bund.bva.isyfact.batchrahmen.batch.konstanten.BatchRahmenEreignisSchluessel;
+import de.bund.bva.isyfact.batchrahmen.batch.protokoll.BatchErgebnisProtokoll;
+import de.bund.bva.isyfact.batchrahmen.batch.protokoll.MeldungTyp;
+import de.bund.bva.isyfact.batchrahmen.batch.protokoll.StatistikEintrag;
+import de.bund.bva.isyfact.batchrahmen.batch.protokoll.VerarbeitungsMeldung;
+import de.bund.bva.isyfact.batchrahmen.batch.rahmen.BatchAusfuehrungsBean;
+import de.bund.bva.isyfact.batchrahmen.batch.rahmen.BatchStartTyp;
+import de.bund.bva.isyfact.batchrahmen.batch.rahmen.VerarbeitungsErgebnis;
+
+/**
+ * Absolute base batch for the {@link de.bund.bva.isyfact.batchrahmen.core.rahmen.Batchrahmen}.
+ * This batch does nothing except increment an internal counter and update the BatchStatus table.
+ */
+public class BasicAuthenticationTestBatch implements BatchAusfuehrungsBean {
+
+    /**
+     * The number of blocks to be written.
+     */
+    public static final int MAX_SAETZE = 10;
+
+    /**
+     * The {@link BatchErgebnisProtokoll}.
+     */
+    private BatchErgebnisProtokoll protokoll;
+
+    /**
+     * The logger.
+     */
+    private static final IsyLogger LOG = IsyLoggerFactory.getLogger(BasicAuthenticationTestBatch.class);
+
+    /**
+     * The {@link StatistikEintrag} for control.
+     */
+    private StatistikEintrag statistik1;
+
+    /**
+     * The {@link StatistikEintrag} for control.
+     */
+    private StatistikEintrag statistik2;
+
+    /**
+     * The internal counter.
+     */
+    private int count;
+
+    public void batchBeendet() {
+        this.statistik2.setWert(999);
+    }
+
+    public void checkpointGeschrieben(long satzNummer) throws BatchAusfuehrungsException {
+        LOG.info(LogKategorie.JOURNAL, BatchRahmenEreignisSchluessel.EPLBAT00001,
+                "Checkpoint für Satz {} geschrieben.", satzNummer);
+    }
+
+    public int initialisieren(BatchKonfiguration konfiguration, long satzNummer, String dbKey,
+                              BatchStartTyp startTyp, Date datumLetzterErfolg, BatchErgebnisProtokoll protokoll)
+            throws BatchAusfuehrungsException {
+        this.count = MAX_SAETZE;
+        this.protokoll = protokoll;
+
+        this.statistik1 = new StatistikEintrag("COUNT", "Zähler");
+        this.statistik2 = new StatistikEintrag("COUNT2", "Zähler 2");
+
+        protokoll.registriereStatistikEintrag(this.statistik1);
+        protokoll.registriereStatistikEintrag(this.statistik2);
+
+        LOG.info(LogKategorie.JOURNAL, BatchRahmenEreignisSchluessel.EPLBAT00001, "Start-Typ ist: {}",
+                startTyp);
+
+        return this.count;
+    }
+
+    public VerarbeitungsErgebnis verarbeiteSatz() throws BatchAusfuehrungsException {
+        this.count--;
+        this.protokoll.ergaenzeMeldung(new VerarbeitungsMeldung("ID" + this.count, "REGNR" + this.count,
+                MeldungTyp.INFO, "Satz " + this.count + " verarbeitet. Teststring: <>\"üaößÜÄÖ€"));
+        this.statistik1.erhoeheWert();
+        return new VerarbeitungsErgebnis(String.valueOf(this.count), this.count == 0);
+    }
+
+    public void rollbackDurchgefuehrt() {
+        LOG.error(BatchRahmenEreignisSchluessel.EPLBAT00001, "Rollback durchgeführt");
+    }
+
+    @Override
+    public void vorCheckpointGeschrieben(long satzNummer) throws BatchAusfuehrungsException {
+        // blank
+    }
+
+    @Override
+    public void vorRollbackDurchgefuehrt() {
+        // blank
+    }
+
+}

--- a/isy-batchrahmen/src/test/java/de/bund/bva/isyfact/batchrahmen/config/AbstractOidcProviderTest.java
+++ b/isy-batchrahmen/src/test/java/de/bund/bva/isyfact/batchrahmen/config/AbstractOidcProviderTest.java
@@ -20,7 +20,7 @@ public abstract class AbstractOidcProviderTest {
      * Authentication and authorization via EmbeddedOidcProviderMock based on WireMock.
      */
     @RegisterExtension
-    public static final EmbeddedOidcProviderMock embeddedOidcProvider = new EmbeddedOidcProviderMock(HOST, PORT, ISSUER_PATH);
+    public static final EmbeddedOidcProviderMock embeddedOidcProvider = new EmbeddedOidcProviderMock(HOST, PORT, ISSUER_PATH, 300);
 
 
     public String getIssuerLocation() {

--- a/isy-batchrahmen/src/test/java/de/bund/bva/isyfact/batchrahmen/test/BatchrahmenTest.java
+++ b/isy-batchrahmen/src/test/java/de/bund/bva/isyfact/batchrahmen/test/BatchrahmenTest.java
@@ -20,11 +20,9 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.resetAllRequests;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -418,7 +416,7 @@ class BatchrahmenTest extends AbstractOidcProviderTest {
                 .run(new String[]{"-start", "-cfg", "/resources/batch/basic-test-batch-1-config.properties"}));
         final LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
         final String actualBatchId = loggerContext.getProperty("BatchId");
-        assertEquals("BatchId ist in Batch LoggerContext gesetzt", "basicTestBatch-1", actualBatchId);
+        assertEquals("basicTestBatch-1", actualBatchId, "BatchId ist in Batch LoggerContext gesetzt");
     }
 
     @Test
@@ -477,9 +475,10 @@ class BatchrahmenTest extends AbstractOidcProviderTest {
         assertEquals(BatchReturnCode.OK.getWert(), BatchLauncher.run(new String[]{"-start", "-cfg",
                 "/resources/batch/basic-authentication-test-batch-authenticated-ropc-config.properties"}));
 
-        // should be called 11 (1 + 10) times, because oauth2MinimumTokenValidity is set to the value of
+        // should be called 11 (1 + 10 + 1) times, because oauth2MinimumTokenValidity is set to the value of
         // tokenLifespan, meaning re-authentication should be done for each step of the batch
-        verify(11, postRequestedFor(urlMatching(ISSUER_PATH + ".*")));
+        // 1x initialisiere, 10x verarbeite, 1x beende
+        verify(12, postRequestedFor(urlMatching(ISSUER_PATH + ".*")));
     }
 
     /**

--- a/isy-batchrahmen/src/test/java/de/bund/bva/isyfact/batchrahmen/test/BatchrahmenTest.java
+++ b/isy-batchrahmen/src/test/java/de/bund/bva/isyfact/batchrahmen/test/BatchrahmenTest.java
@@ -482,4 +482,16 @@ class BatchrahmenTest extends AbstractOidcProviderTest {
         verify(11, postRequestedFor(urlMatching(ISSUER_PATH + ".*")));
     }
 
+    /**
+     * Tests that an exception is thrown when the batch property oauth2MinimumTokenValidity is set to a negative number.
+     */
+    @Test
+    void testBatchInvalidOAuth2MinimumTokenValidityProperty() {
+        assertEquals(BatchReturnCode.FEHLER_KONFIGURATION.getWert(), BatchLauncher.run(new String[]{"-start", "-cfg",
+                "/resources/batch/basic-authentication-test-batch-invalid-minimum-token-validity-config.properties",
+                "-Batchrahmen.Ergebnisdatei", ERGEBNIS_DATEI}));
+        BatchProtokollTester bpt = new BatchProtokollTester(ERGEBNIS_DATEI);
+        assertTrue(bpt.enthaeltFehler("BAT110", "-10"));
+    }
+
 }

--- a/isy-batchrahmen/src/test/resources/resources/batch/basic-authentication-test-batch-authenticated-ropc-config.properties
+++ b/isy-batchrahmen/src/test/resources/resources/batch/basic-authentication-test-batch-authenticated-ropc-config.properties
@@ -1,0 +1,27 @@
+###
+# See the NOTICE file distributed with this work for additional
+# information regarding copyright ownership.
+# The Federal Office of Administration (Bundesverwaltungsamt, BVA)
+# licenses this file to you under the Apache License, Version 2.0 (the
+# License). You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+###
+Batchrahmen.BeanName=batchrahmen
+Anwendung.SpringDateien.1=de.bund.bva.isyfact.batchrahmen.AnwendungTestConfig
+Batchrahmen.SpringDateien.1=de.bund.bva.isyfact.batchrahmen.BatchrahmenTestConfig
+Batchrahmen.CommitIntervall=1000
+Batchrahmen.ClearIntervall=10
+AusfuehrungsBean=basicAuthenticationTestBatch
+BatchId=basicTestBatch-1
+BatchName=basicTestBatch-1
+batch.oauth2ClientRegistrationId=ropc-testclient
+batch.oauth2MinimumTokenValidity=300
+

--- a/isy-batchrahmen/src/test/resources/resources/batch/basic-authentication-test-batch-invalid-minimum-token-validity-config.properties
+++ b/isy-batchrahmen/src/test/resources/resources/batch/basic-authentication-test-batch-invalid-minimum-token-validity-config.properties
@@ -1,0 +1,27 @@
+###
+# See the NOTICE file distributed with this work for additional
+# information regarding copyright ownership.
+# The Federal Office of Administration (Bundesverwaltungsamt, BVA)
+# licenses this file to you under the Apache License, Version 2.0 (the
+# License). You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+###
+Batchrahmen.BeanName=batchrahmen
+Anwendung.SpringDateien.1=de.bund.bva.isyfact.batchrahmen.AnwendungTestConfig
+Batchrahmen.SpringDateien.1=de.bund.bva.isyfact.batchrahmen.BatchrahmenTestConfig
+Batchrahmen.CommitIntervall=1000
+Batchrahmen.ClearIntervall=10
+AusfuehrungsBean=basicAuthenticationTestBatch
+BatchId=basicTestBatch-1
+BatchName=basicTestBatch-1
+batch.oauth2ClientRegistrationId=ropc-testclient
+batch.oauth2MinimumTokenValidity=-10
+

--- a/isy-batchrahmen/src/test/resources/resources/batch/basic-test-batch-authenticated-client-credentials-config.properties
+++ b/isy-batchrahmen/src/test/resources/resources/batch/basic-test-batch-authenticated-client-credentials-config.properties
@@ -1,0 +1,26 @@
+###
+# See the NOTICE file distributed with this work for additional
+# information regarding copyright ownership.
+# The Federal Office of Administration (Bundesverwaltungsamt, BVA)
+# licenses this file to you under the Apache License, Version 2.0 (the
+# License). You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+###
+Batchrahmen.BeanName=batchrahmen
+Anwendung.SpringDateien.1=de.bund.bva.isyfact.batchrahmen.AnwendungTestConfig
+Batchrahmen.SpringDateien.1=de.bund.bva.isyfact.batchrahmen.BatchrahmenTestConfig
+Batchrahmen.CommitIntervall=1000
+Batchrahmen.ClearIntervall=10
+AusfuehrungsBean=basicTestBatch
+BatchId=basicTestBatch-1
+BatchName=basicTestBatch-1
+batch.oauth2ClientRegistrationId=cc-testclient
+

--- a/isy-batchrahmen/src/test/resources/resources/batch/basic-test-batch-authenticated-ropc-config.properties
+++ b/isy-batchrahmen/src/test/resources/resources/batch/basic-test-batch-authenticated-ropc-config.properties
@@ -1,0 +1,26 @@
+###
+# See the NOTICE file distributed with this work for additional
+# information regarding copyright ownership.
+# The Federal Office of Administration (Bundesverwaltungsamt, BVA)
+# licenses this file to you under the Apache License, Version 2.0 (the
+# License). You may not use this file except in compliance with the
+# License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+###
+Batchrahmen.BeanName=batchrahmen
+Anwendung.SpringDateien.1=de.bund.bva.isyfact.batchrahmen.AnwendungTestConfig
+Batchrahmen.SpringDateien.1=de.bund.bva.isyfact.batchrahmen.BatchrahmenTestConfig
+Batchrahmen.CommitIntervall=1000
+Batchrahmen.ClearIntervall=10
+AusfuehrungsBean=basicTestBatch
+BatchId=basicTestBatch-1
+BatchName=basicTestBatch-1
+batch.oauth2ClientRegistrationId=ropc-testclient
+

--- a/isy-security-test/src/main/java/de/bund/bva/isyfact/security/test/oidcprovider/EmbeddedOidcProviderStub.java
+++ b/isy-security-test/src/main/java/de/bund/bva/isyfact/security/test/oidcprovider/EmbeddedOidcProviderStub.java
@@ -178,10 +178,9 @@ public class EmbeddedOidcProviderStub {
     }
 
     public String getAccessTokenResponse(JwtClaimsSet claims) {
-        long lifetime = Instant.now().plusSeconds(tokenLifespan).getEpochSecond();
         Scope scope = Scope.parse("openid profile email");
 
-        BearerAccessToken accessToken = new BearerAccessToken(getAccessTokenString(claims), lifetime, scope);
+        BearerAccessToken accessToken = new BearerAccessToken(getAccessTokenString(claims), tokenLifespan, scope);
         AccessTokenResponse response = new AccessTokenResponse(new Tokens(accessToken, null));
 
         return response.toJSONObject().toJSONString();

--- a/isy-security-test/src/test/java/de/bund/bva/isyfact/security/test/oidcprovider/EmbeddedOidcProviderStubTest.java
+++ b/isy-security-test/src/test/java/de/bund/bva/isyfact/security/test/oidcprovider/EmbeddedOidcProviderStubTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -102,9 +103,9 @@ public class EmbeddedOidcProviderStubTest {
         // test if valid JWT, content is validated in different tests
         assertNotNull(JWTParser.parse(tree.get("access_token").asText()));
         assertEquals("Bearer", tree.get("token_type").asText());
-        Instant expiresIn = Instant.ofEpochSecond(tree.get("expires_in").asLong());
-        assertTrue(expiresIn.isAfter(Instant.now()));
-        assertTrue(expiresIn.isBefore(Instant.now().plusSeconds(tokenLifespan).plusSeconds(60)));
+        Duration expiresIn = Duration.ofSeconds(tree.get("expires_in").asLong());
+        assertTrue(Instant.now().plus(expiresIn).isAfter(Instant.now()));
+        assertTrue(Instant.now().plus(expiresIn).isBefore(Instant.now().plusSeconds(tokenLifespan).plusSeconds(60)));
     }
 
     @Test

--- a/isy-security/CHANGELOG.md
+++ b/isy-security/CHANGELOG.md
@@ -4,6 +4,7 @@
 - `ISY-980`: Anpassung der Dokumentation aufgrund von Security-Umstellungen
 - `IFS-2804`: `@EnableGlobalMethodSecurity` durch die modernere `@EnableMethodSecurity` Annotation ersetzt
   - Aktiviert standardmäßig @PreAuthorize, @PostAuthorize, @PreFilter und @PostFilter (`prePostEnabled = true`)
+- `IFS-2248`: Bereitstellen von Funktionalität zur Token-Gültigkeitsüberprüfung und erneuten Authentifizierung
 
 # 3.0.0
 

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/client/Authentifizierungsmanager.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/client/Authentifizierungsmanager.java
@@ -1,8 +1,12 @@
 package de.bund.bva.isyfact.security.oauth2.client;
 
+import java.time.Duration;
+
 import org.springframework.lang.Nullable;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.server.resource.authentication.AbstractOAuth2TokenAuthenticationToken;
 
 import de.bund.bva.isyfact.security.config.IsyOAuth2ClientConfigurationProperties;
 
@@ -34,6 +38,31 @@ public interface Authentifizierungsmanager {
      *         if authentication fails
      */
     void authentifiziere(String oauth2ClientRegistrationId) throws AuthenticationException;
+
+    /**
+     * Performs authentication for the given {@code oauth2ClientRegistrationId} as described in
+     * {@link Authentifizierungsmanager#authentifiziere(String)} if the SecurityContext does not contain
+     * an Authentication of type {@link AbstractOAuth2TokenAuthenticationToken} or the token received from the
+     * SecurityContext is considered as expired with regard to the {@code expirationTimeOffset}.
+     * The {@code expirationTimeOffset} provides a time frame before token expiry during which the token is considered as already expired.
+     * <p>
+     * For clients configured to use the Client Credentials Flow (grant type: client_credentials), authentication will only reliably
+     * occur for an {@code expirationTimeOffset} less than 60 seconds, because Spring will by default skip authentication in the
+     * {@link org.springframework.security.oauth2.client.ClientCredentialsOAuth2AuthorizedClientProvider ClientCredentialsOAuth2AuthorizedClientProvider}
+     * if the access token provided by the corresponding {@link org.springframework.security.oauth2.client.OAuth2AuthorizedClient OAuth2AuthorizedClient}
+     * does not expire within 60 seconds from current time.
+     * When using this method for re-authentication with the Client Credentials Flow, this means that a time longer
+     * than 60 seconds before the next call of this method could lead to token expiration.
+     *
+     * @param oauth2ClientRegistrationId
+     *         registration ID of the OAuth 2.0 Client to authorize
+     * @param expirationTimeOffset
+     *         the time frame before expiry during which the token is considered as already expired
+     * @throws AuthenticationException
+     *         if authentication fails
+     * @see Authentifizierungsmanager#authentifiziere(String)
+     */
+    void authentifiziere(String oauth2ClientRegistrationId, Duration expirationTimeOffset) throws AuthenticationException;
 
     /**
      * Attempts to create and authorize a client with the given credentials via the OAuth 2.0 Client Credentials Flow.

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/client/IsyOAuth2Authentifizierungsmanager.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/client/IsyOAuth2Authentifizierungsmanager.java
@@ -1,5 +1,7 @@
 package de.bund.bva.isyfact.security.oauth2.client;
 
+import java.time.Duration;
+
 import org.springframework.lang.Nullable;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -18,6 +20,7 @@ import de.bund.bva.isyfact.security.config.IsyOAuth2ClientConfigurationPropertie
 import de.bund.bva.isyfact.security.oauth2.client.authentication.token.ClientCredentialsClientRegistrationAuthenticationToken;
 import de.bund.bva.isyfact.security.oauth2.client.authentication.token.ClientCredentialsRegistrationIdAuthenticationToken;
 import de.bund.bva.isyfact.security.oauth2.client.authentication.token.PasswordClientRegistrationAuthenticationToken;
+import de.bund.bva.isyfact.security.oauth2.util.IsySecurityTokenUtil;
 
 /**
  * Default implementation of the {@link Authentifizierungsmanager} that should suffice for most use cases.
@@ -64,6 +67,13 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
     public void authentifiziere(String oauth2ClientRegistrationId) throws AuthenticationException {
         Authentication unauthenticatedToken = getAuthenticationTokenForRegistrationId(oauth2ClientRegistrationId);
         authenticateAndChangeAuthenticatedPrincipal(unauthenticatedToken);
+    }
+
+    @Override
+    public void authentifiziere(String oauth2ClientRegistrationId, Duration expirationTimeOffset) throws AuthenticationException {
+        if (!IsySecurityTokenUtil.hasOAuth2Token() || IsySecurityTokenUtil.hasTokenExpired(expirationTimeOffset)) {
+            authentifiziere(oauth2ClientRegistrationId);
+        }
     }
 
     @Override

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenUtil.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenUtil.java
@@ -7,7 +7,6 @@ import java.util.ResourceBundle;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.core.AbstractOAuth2Token;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2Token;
 import org.springframework.security.oauth2.core.oidc.StandardClaimNames;
@@ -17,7 +16,7 @@ import org.springframework.security.oauth2.server.resource.authentication.Abstra
 /**
  * This class contains utility methods for isy-security. It provides access to the claims of the current OAuth 2.0 token.
  */
-public class IsySecurityTokenUtil {
+public final class IsySecurityTokenUtil {
 
 
     /**
@@ -57,6 +56,12 @@ public class IsySecurityTokenUtil {
      */
     private static String getConfigPropertyValueAsString(String suffix) {
         return BUNDLE.getString(PREFIX + suffix);
+    }
+
+    /**
+     * Utility class should not be instantiated.
+     */
+    private IsySecurityTokenUtil() {
     }
 
     /**
@@ -131,11 +136,9 @@ public class IsySecurityTokenUtil {
      *         if the authenticated principal is not a {@link AbstractOAuth2TokenAuthenticationToken}
      */
     public static boolean hasTokenExpired(Duration expirationTimeOffset) {
-        AbstractOAuth2Token token = getAuthenticationToken().getToken();
-        if (token.getExpiresAt() != null) {
-            return Instant.now().isAfter(token.getExpiresAt().minus(expirationTimeOffset));
-        }
-        return true;
+        return Optional.ofNullable(getAuthenticationToken().getToken().getExpiresAt())
+                .map(expiresAt -> Instant.now().isAfter(expiresAt.minus(expirationTimeOffset)))
+                .orElse(true);
     }
 
     /**

--- a/isy-security/src/test/java/de/bund/bva/isyfact/security/AbstractOidcProviderTest.java
+++ b/isy-security/src/test/java/de/bund/bva/isyfact/security/AbstractOidcProviderTest.java
@@ -23,7 +23,7 @@ public abstract class AbstractOidcProviderTest {
      * Authentication and authorization via EmbeddedOidcProviderMock based on WireMock.
      */
     @RegisterExtension
-    public static final EmbeddedOidcProviderMock embeddedOidcProvider = new EmbeddedOidcProviderMock(HOST, PORT, ISSUER_PATH);
+    public static final EmbeddedOidcProviderMock embeddedOidcProvider = new EmbeddedOidcProviderMock(HOST, PORT, ISSUER_PATH, 300);
 
     protected static void registerTestClients() {
         // client with authorization-grant-type=password

--- a/isy-security/src/test/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenUtilTest.java
+++ b/isy-security/src/test/java/de/bund/bva/isyfact/security/oauth2/util/IsySecurityTokenUtilTest.java
@@ -1,8 +1,6 @@
 package de.bund.bva.isyfact.security.oauth2.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -18,7 +16,10 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.oidc.StandardClaimNames;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.AbstractOAuth2TokenAuthenticationToken;
@@ -173,7 +174,7 @@ public class IsySecurityTokenUtilTest {
         SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(token));
 
         assertTrue(IsySecurityTokenUtil.hasTokenExpired(Duration.ofSeconds(61)));
-        verify(token, times(2)).getExpiresAt();
+        verify(token).getExpiresAt();
     }
 
     @Test
@@ -186,7 +187,7 @@ public class IsySecurityTokenUtilTest {
         SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(token));
 
         assertFalse(IsySecurityTokenUtil.hasTokenExpired(Duration.ofSeconds(60)));
-        verify(token, times(2)).getExpiresAt();
+        verify(token).getExpiresAt();
     }
 
     @Test
@@ -197,7 +198,15 @@ public class IsySecurityTokenUtilTest {
         SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(token));
 
         assertTrue(IsySecurityTokenUtil.hasTokenExpired(Duration.ofSeconds(60)));
-        verify(token, times(1)).getExpiresAt();
+        verify(token).getExpiresAt();
+    }
+
+    @Test
+    public void getAuthenticationTokenThrowsExceptionWhenTokenIsNotOAuth2() {
+        Authentication notOAuth2Authentication = new TestingAuthenticationToken("principal", "credentials");
+        SecurityContextHolder.getContext().setAuthentication(notOAuth2Authentication);
+
+        assertThrows(OAuth2AuthenticationException.class, IsySecurityTokenUtil::getAuthenticationToken);
     }
 
     private void mockSecurityContextWithTokenAttributes(Map<String, Object> attributes) {


### PR DESCRIPTION
* feat: IFS-2248 add functionality to check token expiration and availability of AbstractOAuth2TokenAuthenticationToken in SecurityContext, refactor methods
* feat: IFS-2248 add functionality for (re-)authentication to IsyOAuth2Authentifizierungsmanager
* test: IFS-2248 add test cases for token expiration check in IsySecurityTokenUtil
* feat: IFS-2248 add Batchrahmen configuration key for minimum token validity
* feat: IFS-2248 add code for re-authentication to BatchrahmenImpl
* test: IFS-2248 fix token life-time in EmbeddedOidcProviderStub, adjust test classes accordingly in order to avoid failures
* test: IFS-2248 add test cases for authentication in Batchrahmen, adjust tokenLifespan in order to avoid unnecessary re-authentication
* feat: IFS-2248 throw BatchrahmenKonfigurationException when minimum token validity is configured as a negative number, add corresponding test case
* chore: IFS-2248 remove outdated javadoc comment from BatchrahmenImpl
* chore: IFS-2248 update changelog