### PR TITLE
chore: IFS-3716 delete templates for Systementwurf and Systemhandbuch

### DIFF
--- a/isyfact-standards-doc/src/docs/antora/modules/methodik/attachments/vorlage-generated/IsyFact-Vorlage-Systementwurf.pdf
+++ b/isyfact-standards-doc/src/docs/antora/modules/methodik/attachments/vorlage-generated/IsyFact-Vorlage-Systementwurf.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f6d95c7523c2d3ba6ad0f3f8440972e03145d397f613ad50b23b3e2f24ddb968
-size 2546688

--- a/isyfact-standards-doc/src/docs/antora/modules/methodik/attachments/vorlage-generated/IsyFact-Vorlage-Systementwurf.zip
+++ b/isyfact-standards-doc/src/docs/antora/modules/methodik/attachments/vorlage-generated/IsyFact-Vorlage-Systementwurf.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b2808e6b15db75b550be0a46cdb4be99162ac85f28ce6ce236b1fb214a6ccbfa
-size 2119302

--- a/isyfact-standards-doc/src/docs/antora/modules/methodik/attachments/vorlage-generated/IsyFact-Vorlage-Systemhandbuch.pdf
+++ b/isyfact-standards-doc/src/docs/antora/modules/methodik/attachments/vorlage-generated/IsyFact-Vorlage-Systemhandbuch.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7c0cdd85bcea1c60ef61be4d0aae7792f8a04e423df47ebed68ae17b09384612
-size 591886

--- a/isyfact-standards-doc/src/docs/antora/modules/methodik/attachments/vorlage-generated/IsyFact-Vorlage-Systemhandbuch.zip
+++ b/isyfact-standards-doc/src/docs/antora/modules/methodik/attachments/vorlage-generated/IsyFact-Vorlage-Systemhandbuch.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:68e4ae0066ce2d3bce59b760a64f91ae8ecaf46a1ffff6393c51af261e21d542
-size 22970


### PR DESCRIPTION
The templates are generated by the doc build.