### PR TITLE
[Issue 383] Brücke zwischen isy-security und isy-sicherheit

### DIFF
--- a/isy-sicherheit/pom.xml
+++ b/isy-sicherheit/pom.xml
@@ -45,6 +45,10 @@
             <groupId>de.bund.bva.isyfact</groupId>
             <artifactId>isy-logging</artifactId>
         </dependency>
+        <dependency>
+            <groupId>de.bund.bva.isyfact</groupId>
+            <artifactId>isy-security</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>

--- a/isy-sicherheit/src/main/java/de/bund/bva/isyfact/sicherheit/autoconfigure/IsySicherheitAutoConfiguration.java
+++ b/isy-sicherheit/src/main/java/de/bund/bva/isyfact/sicherheit/autoconfigure/IsySicherheitAutoConfiguration.java
@@ -1,13 +1,5 @@
 package de.bund.bva.isyfact.sicherheit.autoconfigure;
 
-import de.bund.bva.isyfact.aufrufkontext.AufrufKontextFactory;
-import de.bund.bva.isyfact.aufrufkontext.impl.AufrufKontextFactoryImpl;
-import de.bund.bva.isyfact.sicherheit.Sicherheit;
-import de.bund.bva.isyfact.sicherheit.SicherheitAdmin;
-import de.bund.bva.isyfact.sicherheit.annotation.GesichertInterceptor;
-import de.bund.bva.isyfact.sicherheit.config.IsySicherheitConfigurationProperties;
-import de.bund.bva.isyfact.sicherheit.impl.SicherheitAdminImpl;
-import de.bund.bva.isyfact.sicherheit.accessmgr.AccessManager;
 import org.springframework.aop.Advisor;
 import org.springframework.aop.aspectj.AspectJExpressionPointcut;
 import org.springframework.aop.support.DefaultPointcutAdvisor;
@@ -20,6 +12,20 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.SimpleThreadScope;
 import org.springframework.web.context.request.RequestScope;
+
+import de.bund.bva.isyfact.aufrufkontext.AufrufKontext;
+import de.bund.bva.isyfact.aufrufkontext.AufrufKontextFactory;
+import de.bund.bva.isyfact.aufrufkontext.impl.AufrufKontextFactoryImpl;
+import de.bund.bva.isyfact.security.core.Berechtigungsmanager;
+import de.bund.bva.isyfact.security.core.Security;
+import de.bund.bva.isyfact.sicherheit.Sicherheit;
+import de.bund.bva.isyfact.sicherheit.SicherheitAdmin;
+import de.bund.bva.isyfact.sicherheit.accessmgr.AccessManager;
+import de.bund.bva.isyfact.sicherheit.annotation.GesichertInterceptor;
+import de.bund.bva.isyfact.sicherheit.config.IsySicherheitConfigurationProperties;
+import de.bund.bva.isyfact.sicherheit.impl.IsySecurityBerechtigungsmanagerImpl;
+import de.bund.bva.isyfact.sicherheit.impl.IsySecurityImpl;
+import de.bund.bva.isyfact.sicherheit.impl.SicherheitAdminImpl;
 
 /**
  * @deprecated since IsyFact 3.0.0 in favor of the isy-security module.
@@ -67,5 +73,17 @@ public class IsySicherheitAutoConfiguration {
     @ConditionalOnBean(AccessManager.class)
     public SicherheitAdmin sicherheitAdmin(AccessManager accessManager) {
         return new SicherheitAdminImpl(accessManager);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(Security.class)
+    public Security isySecurity(Sicherheit<AufrufKontext> sicherheit) {
+        return new IsySecurityImpl(sicherheit);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(Berechtigungsmanager.class)
+    public Berechtigungsmanager isySecurityBerechtigungsmanager(Sicherheit<AufrufKontext> sicherheit) {
+        return new IsySecurityBerechtigungsmanagerImpl(sicherheit);
     }
 }

--- a/isy-sicherheit/src/main/java/de/bund/bva/isyfact/sicherheit/impl/IsySecurityBerechtigungsmanagerImpl.java
+++ b/isy-sicherheit/src/main/java/de/bund/bva/isyfact/sicherheit/impl/IsySecurityBerechtigungsmanagerImpl.java
@@ -1,0 +1,64 @@
+package de.bund.bva.isyfact.sicherheit.impl;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.security.access.AccessDeniedException;
+
+import de.bund.bva.isyfact.aufrufkontext.AufrufKontext;
+import de.bund.bva.isyfact.security.core.Berechtigungsmanager;
+import de.bund.bva.isyfact.sicherheit.Recht;
+import de.bund.bva.isyfact.sicherheit.Rolle;
+import de.bund.bva.isyfact.sicherheit.Sicherheit;
+
+/**
+ * Mit IsyFact 3 kommt eine neue Bibliothek isy-security. Die alte Bibliothek isy-sicherheit ist deprecated.
+ * Komponenten (wie beispielsweise SchlüsselverzeichnisClient), die bereits auf isy-security umgestellt sind,
+ * funktionieren nicht mehr ohne weiteres, wenn isy-sicherheit anstatt isy-security genutzt wird.
+ * Im folgenden werden Beans für die Interfaces von isy-security erstellt, die aber durch isy-sicherheit
+ * implementiert werden.
+ *
+ * @deprecated Muss beim Umstellung von isy-sicherheit auf isy-security entfernt werden.
+ */
+@Deprecated
+public class IsySecurityBerechtigungsmanagerImpl implements Berechtigungsmanager {
+
+    private final Sicherheit<AufrufKontext> sicherheit;
+
+    public IsySecurityBerechtigungsmanagerImpl(Sicherheit<AufrufKontext> sicherheit) {
+        this.sicherheit = sicherheit;
+    }
+
+    @Override
+    public void pruefeRecht(String recht) throws AccessDeniedException {
+        this.sicherheit.getBerechtigungsManager().pruefeRecht(recht);
+    }
+
+    @Override
+    public boolean hatRecht(String recht) {
+        return this.sicherheit.getBerechtigungsManager().hatRecht(recht);
+    }
+
+    @Override
+    public Set<String> getRollen() {
+        return this.sicherheit.getBerechtigungsManager()
+            .getRollen()
+            .stream()
+            .map(Rolle::getId)
+            .collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<String> getRechte() {
+        return this.sicherheit.getBerechtigungsManager()
+            .getRechte()
+            .stream()
+            .map(Recht::getId)
+            .collect(Collectors.toSet());
+    }
+
+    @Override
+    public Object getTokenAttribute(String key) {
+        return null;
+    }
+}

--- a/isy-sicherheit/src/main/java/de/bund/bva/isyfact/sicherheit/impl/IsySecurityImpl.java
+++ b/isy-sicherheit/src/main/java/de/bund/bva/isyfact/sicherheit/impl/IsySecurityImpl.java
@@ -1,0 +1,50 @@
+package de.bund.bva.isyfact.sicherheit.impl;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import de.bund.bva.isyfact.aufrufkontext.AufrufKontext;
+import de.bund.bva.isyfact.security.core.Berechtigungsmanager;
+import de.bund.bva.isyfact.security.core.Security;
+import de.bund.bva.isyfact.security.oauth2.client.Authentifizierungsmanager;
+import de.bund.bva.isyfact.sicherheit.Rolle;
+import de.bund.bva.isyfact.sicherheit.Sicherheit;
+
+/**
+ * Mit IsyFact 3 kommt eine neue Bibliothek isy-security. Die alte Bibliothek isy-sicherheit ist deprecated.
+ * Komponenten (wie beispielsweise SchlüsselverzeichnisClient), die bereits auf isy-security umgestellt sind,
+ * funktionieren nicht mehr ohne weiteres, wenn isy-sicherheit anstatt isy-security genutzt wird.
+ * Im folgenden werden Beans für die Interfaces von isy-security erstellt, die aber durch isy-sicherheit
+ * implementiert werden.
+ *
+ * @deprecated Muss beim Umstellung von isy-sicherheit auf isy-security entfernt werden.
+ */
+@Deprecated
+public class IsySecurityImpl implements Security {
+
+    private final Sicherheit<AufrufKontext> sicherheit;
+
+    public IsySecurityImpl(Sicherheit<AufrufKontext> sicherheit) {
+        this.sicherheit = sicherheit;
+    }
+
+    @Override
+    public Optional<Authentifizierungsmanager> getAuthentifizierungsmanager() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Berechtigungsmanager getBerechtigungsmanager() {
+        return new IsySecurityBerechtigungsmanagerImpl(this.sicherheit);
+    }
+
+    @Override
+    public Set<String> getAlleRollen() {
+        final Set<Rolle> rollen = this.sicherheit.getAlleRollen();
+        return rollen
+            .stream()
+            .map(Rolle::getId)
+            .collect(Collectors.toSet());
+    }
+}


### PR DESCRIPTION
Workaround für https://github.com/IsyFact/isyfact-standards/issues/383

Der Workaround fügt in isy-sicherheit Implementierungen der Interfaces von isy-security auf Basis von isy-sicherheit ein. Dies erlaubt die Verwendung von IsyFact Bibliotheken, die bereits auf isy-security umgestellt sind, mit isy-sicherheit.

Durch den Workaround hat isy-sicherheit jetzt eine Abhängigkeit zu isy-security. Dies könnte sicher eleganter gelöst werden, indem die Verbindung zwischen isy-sicherheit und isy-security in ein eigenes Modul verschoben wird. Dies wurde hier aus Aufwandsgründen nicht gemacht, da isy-sicherheit deprecated ist.