### PR TITLE
[Sprint 105] IFS-2804 method security documentation

### DIFF
--- a/isy-batchrahmen/src/test/java/de/bund/bva/isyfact/batchrahmen/AnwendungTestConfig.java
+++ b/isy-batchrahmen/src/test/java/de/bund/bva/isyfact/batchrahmen/AnwendungTestConfig.java
@@ -1,41 +1,29 @@
 package de.bund.bva.isyfact.batchrahmen;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import jakarta.persistence.EntityManagerFactory;
+
 import javax.sql.DataSource;
 
 import org.h2.jdbcx.JdbcDataSource;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientPropertiesRegistrationAdapter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
-import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.orm.jpa.vendor.Database;
 import org.springframework.orm.jpa.vendor.HibernateJpaDialect;
 import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.oauth2.client.registration.ClientRegistration;
-import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
-
-import de.bund.bva.isyfact.security.autoconfigure.IsyOAuth2ClientAutoConfiguration;
-import de.bund.bva.isyfact.security.autoconfigure.IsySecurityAutoConfiguration;
 
 @Configuration
 @EnableTransactionManagement
 @EnableAspectJAutoProxy
 @EnableAutoConfiguration
-@EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true)
 public class AnwendungTestConfig {
 
 

--- a/isy-security/CHANGELOG.md
+++ b/isy-security/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - `ISY-305`: Implementierung von IsySecurityTokenUtil zum Auslesen von Attributen aus dem Bearer Token
 - `ISY-980`: Anpassung der Dokumentation aufgrund von Security-Umstellungen
+- `IFS-2804`: Entfernen der `@EnableMethodSecurity` Annotation von `IsySecurityAutoConfiguration`
+    - Die Annotation muss in der Anwendung selbst gesetzt werden um Method Security zu aktivieren
 
 # 3.0.0
 

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/autoconfigure/IsySecurityAutoConfiguration.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/autoconfigure/IsySecurityAutoConfiguration.java
@@ -7,7 +7,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.lang.Nullable;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.core.GrantedAuthorityDefaults;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
@@ -27,7 +26,6 @@ import de.bund.bva.isyfact.security.xmlparser.RolePrivilegesMapper;
 @ConditionalOnClass(EnableWebSecurity.class)
 @AutoConfiguration
 @EnableConfigurationProperties
-@EnableGlobalMethodSecurity(securedEnabled = true)
 public class IsySecurityAutoConfiguration {
 
     @Bean

--- a/isy-security/src/test/java/de/bund/bva/isyfact/security/IsySecurityTestConfiguration.java
+++ b/isy-security/src/test/java/de/bund/bva/isyfact/security/IsySecurityTestConfiguration.java
@@ -2,6 +2,7 @@ package de.bund.bva.isyfact.security;
 
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 
 /**
  * Test configuration for isy-security. Only scans for auto configurations.
@@ -11,6 +12,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
  */
 @SpringBootConfiguration
 @EnableAutoConfiguration
+@EnableMethodSecurity(securedEnabled = true)
 public class IsySecurityTestConfiguration {
 
 }

--- a/isy-security/src/test/java/de/bund/bva/isyfact/security/authentication/AuthorityPrefixTest.java
+++ b/isy-security/src/test/java/de/bund/bva/isyfact/security/authentication/AuthorityPrefixTest.java
@@ -13,10 +13,10 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 import de.bund.bva.isyfact.security.IsySecurityTestConfiguration;
 
-@SpringBootTest(classes = { IsySecurityTestConfiguration.class, AuthorityPrefixTest.AnnotationTest.class })
+@SpringBootTest(classes = {IsySecurityTestConfiguration.class, AuthorityPrefixTest.AnnotationTest.class})
 public class AuthorityPrefixTest {
 
-    private static final String[] TEST_AUTHORITIES = { "PRIV_test", "ROLE_test" };
+    private static final String[] TEST_AUTHORITIES = {"PRIV_test"};
 
     @Autowired
     private AnnotationTest annotationTest;

--- a/isy-security/src/test/java/de/bund/bva/isyfact/security/oauth2/client/annotation/MethodAuthenticationTest.java
+++ b/isy-security/src/test/java/de/bund/bva/isyfact/security/oauth2/client/annotation/MethodAuthenticationTest.java
@@ -18,6 +18,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -30,6 +31,7 @@ import de.bund.bva.isyfact.security.oauth2.client.Authentifizierungsmanager;
         properties = { "test.auth.client-id = my-auth-client" }
 )
 @EnableAutoConfiguration
+@EnableMethodSecurity(securedEnabled = true)
 public class MethodAuthenticationTest {
 
     private static final String[] TEST_AUTHORITIES = { "PRIV_test", "ROLE_test" };

--- a/isy-task/src/test/java/de/bund/bva/isyfact/task/test/config/TestConfig.java
+++ b/isy-task/src/test/java/de/bund/bva/isyfact/task/test/config/TestConfig.java
@@ -4,11 +4,13 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.ResourceBundleMessageSource;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 
 import de.bund.bva.isyfact.util.spring.MessageSourceHolder;
 
 @Configuration
 @EnableAutoConfiguration
+@EnableMethodSecurity(securedEnabled = true)
 public class TestConfig {
 
     @Bean

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/inhalt.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/inhalt.adoc
@@ -496,7 +496,42 @@ public void abgesicherteMethode(/* ... */) {
 
 Als Parameter wird ein Array von Rechten übergeben.
 Die Rechte sind disjunktiv verknüpft.
-Die Autorisierung erfolgt dementsprechend wenn der Nutzer mindestens eins der in der `Secured` Annotation übergebenen Rechte besitzt.
+Die Autorisierung erfolgt dementsprechend wenn der Nutzer mindestens eines der in der `Secured`-Annotation übergebenen Rechte besitzt.
+
+Um konjunktive Verknüpfungen umzusetzen, sollte die Annotation `@PreAuthorize` aus Spring Security verwendet werden.
+`@PreAuthorize` ist für die Prüfung eines einzigen Rechtes äquivalent zu `@Secured`, nutzt aber die Spring Expression Language (SpEL).
+
+Dadurch sind Ausdrücke möglich wie:
+
+[source,java]
+----
+@PreAuthorize("hasAuthority('PRIV_Recht_A') and hasAuthority('PRIV_Recht_B')")
+----
+
+Die annotationsbasierte Autorisierung auf Methoden-/Klassenlevel muss durch setzen der `@EnableMethodSecurity`-Annotation an einer `@Configuration`-Klasse aktiviert werden.
+Dabei kann mit den Optionen `securedEnabled` und `prePostEnabled` die Verwendung von `@Secured` und `@PreAuthorize` aktiviert/deaktiviert werden.
+Die Option `prePostEnabled` ist standardmäßig aktiviert.
+
+[[listing-enable-method-security]]
+.Aktivierung der Method Security
+[source,java]
+----
+@Configuration
+@EnableMethodSecurity(securedEnabled = true, prePostEnabled = true)
+public class SecurityConfiguration {
+    // ...
+}
+----
+
+[IMPORTANT]
+====
+Method Level Security ist für die Nutzung in der Service Schicht.
+Die Verwendung an `@Controller` Klassen/Methoden kann zu Fehlern führen und wird nicht empfohlen.
+Für Webcontroller ohne Service-Schicht kann https://docs.spring.io/spring-security/reference/servlet/authorization/authorize-http-requests.html[Request Level Autorisierung] genutzt werden.
+
+Das mehrfache setzen der `@EnableMethodSecurity`-Annotation sollte vermieden werden.
+Mit abweichender Konfiguration kann dies zu unerwartetem Verhalten und Fehlern führen.
+====
 
 [[attr-token-abfragen]]
 == Attribute aus dem Bearer Token abfragen

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-service-rest/pages/konzept/inhalt.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-service-rest/pages/konzept/inhalt.adoc
@@ -881,7 +881,8 @@ Nähere Informationen zu OAuth2 gibt es auf der https://oauth.net/2/[OAuth2 Home
 Informationen zur Bearer Propagation gibt es in der https://docs.spring.io/spring-security/site/docs/5.2.x/reference/html/oauth2.html#oauth2resourceserver-bearertoken-resolver[offiziellen Spring Dokumentation].
 ====
 
-Um eine Klasse oder einzelne Methoden zu sichern, ist die `@Secured` Annotation des Bausteins Security zu verwendet.
+Um eine Klasse oder einzelne Methoden zu sichern, wird empfohlen, die `@Secured` Annotation von Spring Security in der Service-Schicht zu verwenden.
+Die Verwendung auf einzelnen Webcontroller Klassen/Methoden wird nicht empfohlen. Für Webcontroller ohne Service Schicht kann https://docs.spring.io/spring-security/reference/servlet/authorization/authorize-http-requests.html[Request Level Autorisierung] genutzt werden.
 
 Generell ist das xref:isy-security:konzept/master.adoc[Konzept der Sicherheitsarchitektur] zu beachten.
 

--- a/isyfact-standards-doc/src/docs/antora/modules/release/pages/migrationsleitfaden.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/release/pages/migrationsleitfaden.adoc
@@ -23,6 +23,13 @@ Folgende Bausteine entfallen in IsyFact 4:
 
 ...
 
+[[isy-security]]
+=== Security
+Method Security ist in der IsyFact 4 version von isy-security standardmäßig nicht mehr aktiviert und muss durch setzen der `@EnableMethodSecurity`- Annotation an einer `@Configuration`-Klasse aktiviert werden.
+
+Detaillierte Konfigurationsmöglichkeiten sind den
+xref:isy-security:nutzungsvorgaben/master.adoc#autorisierung_service_schnittstelle[Nutzungsvorgaben Security] und der https://docs.spring.io/spring-security/reference/servlet/authorization/method-security.html[Spring Security Dokumentation] zu entnehmen.
+
 [[isy-ueberwachung]]
 === Überwachung
 


### PR DESCRIPTION
* docs: IFS-2804 recommend usage of @Secured annotation at Service level
* feat: IFS-2804 remove @EnableMethodSecurity Annotation fom Autoconfiguration

    * describe required usage of @EnableMethodSecurity Annotation
    * describe usage of @PreAuthorize