### PR TITLE
[Sprint 105] IFS-2804 method security documentation 3.x

### DIFF
--- a/isy-security/CHANGELOG.md
+++ b/isy-security/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - `ISY-305`: Implementierung von IsySecurityTokenUtil zum Auslesen von Attributen aus dem Bearer Token
 - `ISY-980`: Anpassung der Dokumentation aufgrund von Security-Umstellungen
+- `IFS-2804`: `@EnableGlobalMethodSecurity` durch die modernere `@EnableMethodSecurity` Annotation ersetzt
+  - Aktiviert standardmäßig @PreAuthorize, @PostAuthorize, @PreFilter und @PostFilter (`prePostEnabled = true`)
 
 # 3.0.0
 

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/autoconfigure/IsyEnableMethodSecurityAutoConfiguration.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/autoconfigure/IsyEnableMethodSecurityAutoConfiguration.java
@@ -1,0 +1,15 @@
+package de.bund.bva.isyfact.security.autoconfigure;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+
+/**
+ * isy-security AutoConfiguration to enable Method Security for usage with @Secured and @PreAuthorize Annotations.
+ *
+ * @deprecated since IsyFact 3.1.0, to be removed in IsyFact 4.0.0. Applications are expected to set the annotation if required.
+ */
+@AutoConfiguration
+@EnableMethodSecurity(securedEnabled = true)
+@Deprecated
+public class IsyEnableMethodSecurityAutoConfiguration {
+}

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/autoconfigure/IsySecurityAutoConfiguration.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/autoconfigure/IsySecurityAutoConfiguration.java
@@ -7,18 +7,17 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.lang.Nullable;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.core.GrantedAuthorityDefaults;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 
-import de.bund.bva.isyfact.security.oauth2.client.Authentifizierungsmanager;
-import de.bund.bva.isyfact.security.core.Berechtigungsmanager;
-import de.bund.bva.isyfact.security.core.Security;
 import de.bund.bva.isyfact.security.authentication.RolePrivilegeGrantedAuthoritiesConverter;
 import de.bund.bva.isyfact.security.config.IsySecurityConfigurationProperties;
+import de.bund.bva.isyfact.security.core.Berechtigungsmanager;
 import de.bund.bva.isyfact.security.core.IsyOAuth2Berechtigungsmanager;
 import de.bund.bva.isyfact.security.core.IsyOAuth2Security;
+import de.bund.bva.isyfact.security.core.Security;
+import de.bund.bva.isyfact.security.oauth2.client.Authentifizierungsmanager;
 import de.bund.bva.isyfact.security.xmlparser.RolePrivilegesMapper;
 
 /**
@@ -27,7 +26,6 @@ import de.bund.bva.isyfact.security.xmlparser.RolePrivilegesMapper;
 @ConditionalOnClass(EnableWebSecurity.class)
 @AutoConfiguration
 @EnableConfigurationProperties
-@EnableGlobalMethodSecurity(securedEnabled = true)
 public class IsySecurityAutoConfiguration {
 
     @Bean

--- a/isy-security/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/isy-security/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,3 @@
-de.bund.bva.isyfact.security.autoconfigure.IsySecurityAutoConfiguration
+de.bund.bva.isyfact.security.autoconfigure.IsyEnableMethodSecurityAutoConfiguration
 de.bund.bva.isyfact.security.autoconfigure.IsyOAuth2ClientAutoConfiguration
+de.bund.bva.isyfact.security.autoconfigure.IsySecurityAutoConfiguration

--- a/isy-security/src/test/java/de/bund/bva/isyfact/security/authentication/AuthorityPrefixTest.java
+++ b/isy-security/src/test/java/de/bund/bva/isyfact/security/authentication/AuthorityPrefixTest.java
@@ -1,6 +1,6 @@
 package de.bund.bva.isyfact.security.authentication;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,7 +16,7 @@ import de.bund.bva.isyfact.security.IsySecurityTestConfiguration;
 @SpringBootTest(classes = { IsySecurityTestConfiguration.class, AuthorityPrefixTest.AnnotationTest.class })
 public class AuthorityPrefixTest {
 
-    private static final String[] TEST_AUTHORITIES = { "PRIV_test", "ROLE_test" };
+    private static final String[] TEST_AUTHORITIES = {"PRIV_test"};
 
     @Autowired
     private AnnotationTest annotationTest;

--- a/isyfact-standards-doc/src/docs/antora/modules/changelog/pages/migrationsleitfaden.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/changelog/pages/migrationsleitfaden.adoc
@@ -297,17 +297,15 @@ Dies verdeutlicht die Abgrenzung zu Rollen, für die Spring das Präfix `ROLE_` 
 Werden mehrere Rechte an die Annotation übergeben, so sind sie bei `@Gesichert` konjunktiv verknüpft (= alle übergebenen Rechte müssen vorhanden sein).
 Bei der Verwendung von `@Secured` sind die übergebenen Rechte hingegen disjunktiv verknüpft (= es genügt, wenn eines der Rechte vorhanden ist).
 
-Um konjunktive Verknüpfungen auch weiterhin umzusetzen, sollte `@PreAuthorize`  verwendet werden.
-`@PreAuthorize` ist für die Prüfung eines einzigen Rechtes äquivalent zu `@Secured`, nutzt aber die Spring Expression Language.
-Daher sind Ausdrücke möglich wie
+Um konjunktive Verknüpfungen auch weiterhin umzusetzen, sollte die Annotation `@PreAuthorize` aus Spring Security verwendet werden.
+`@PreAuthorize` ist für die Prüfung eines einzigen Rechtes äquivalent zu `@Secured`, nutzt aber die Spring Expression Language (SpEL).
 
-[source]
+Dadurch sind Ausdrücke möglich wie
+
+[source,java]
 ----
 @PreAuthorize("hasAuthority('PRIV_Recht_A') and hasAuthority('PRIV_Recht_B')")
 ----
-In `isy-security` ist die Verwendung von `@PreAuthorize` nicht aktiviert.
-Falls `@PreAuthorize` verwendet werden soll, muss die Verwendung im aufrufenden Projekt mit der Konfiguration `@EnableGlobalMethodSecurity(securedEnabled = true, prePostEnabled = true)` erlaubt werden.
-Alternativ kann in diesem Fall auch die neuere Annotation `@EnableMethodSecurity` verwendet werden, bei der `prePostEnabled = true` standardmäßig gesetzt ist.
 ====
 
 [[sicherheit-berechtigungsmanager]]

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/inhalt.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/inhalt.adoc
@@ -485,14 +485,55 @@ Folgendes Beispiel (<<listing-absichern-einer-service-methode>>) verdeutlicht di
 [source,java]
 ----
 @Secured({ "PRIV_RechtA", "PRIV_RechtB" })
-public void abgesicherteMethode(...) {
-    ...
+public void abgesicherteMethode(/* ... */) {
+    // ...
 }
 ----
 
 Als Parameter wird ein Array von Rechten übergeben.
 Die Rechte sind disjunktiv verknüpft.
-Die Autorisierung erfolgt dementsprechend wenn der Nutzer mindestens eins der in der `Secured` Annotation übergebenen Rechte besitzt.
+Die Autorisierung erfolgt dementsprechend wenn der Nutzer mindestens eines der in der `Secured`-Annotation übergebenen Rechte besitzt.
+
+Um konjunktive Verknüpfungen umzusetzen, sollte die Annotation `@PreAuthorize` aus Spring Security verwendet werden.
+`@PreAuthorize` ist für die Prüfung eines einzigen Rechtes äquivalent zu `@Secured`, nutzt aber die Spring Expression Language (SpEL).
+
+Dadurch sind Ausdrücke möglich wie:
+
+[source,java]
+----
+@PreAuthorize("hasAuthority('PRIV_Recht_A') and hasAuthority('PRIV_Recht_B')")
+----
+
+Standardmäßig aktiviert die isy-security AutoConfiguration Method Security durch die `@EnableMethodSecurity`-Annotation mit der Option `securedEnabled = true`.
+Die Option `prePostEnabled` ist per default aktiv.
+
+[[listing-enable-method-security]]
+.Standard Aktivierung der Method Security per AutoConfiguration
+[source,java]
+----
+@Configuration
+@EnableMethodSecurity(securedEnabled = true)
+public class IsyEnableMethodSecurityAutoConfiguration {
+    // ...
+}
+----
+
+Sollte der Bedarf bestehen, die `@EnableMethodSecurity`-Annotation zu überschreiben, die `@EnableGlobalMethodSecurity`-Annotation zu verwenden oder Method Security zu deaktivieren, so wird empfohlen die entsprechende AutoConfiguration Klasse aus isy-security zu excludieren:
+
+[source,properties]
+----
+spring.autoconfigure.exclude=de.bund.bva.isyfact.security.autoconfigure.IsyEnableMethodSecurityAutoConfiguration
+----
+
+[IMPORTANT]
+====
+Method Level Security ist für die Nutzung in der Service Schicht.
+Die Verwendung an `@Controller` Klassen/Methoden kann zu Fehlern führen und wird nicht empfohlen.
+Für Webcontroller ohne Service-Schicht kann https://docs.spring.io/spring-security/reference/servlet/authorization/authorize-http-requests.html[Request Level Autorisierung] genutzt werden.
+
+Das mehrfache setzen der `@EnableMethodSecurity`-Annotation sollte vermieden werden.
+Mit abweichender Konfiguration kann dies zu unerwartetem Verhalten und Fehlern führen.
+====
 
 [[attr-token-abfragen]]
 == Attribute aus dem Bearer Token abfragen

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-service-rest/pages/konzept/inhalt.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-service-rest/pages/konzept/inhalt.adoc
@@ -879,7 +879,9 @@ Nähere Informationen zu OAuth2 gibt es auf der xref:literaturextern:inhalt.adoc
 Informationen zur Bearer Propagation gibt es in der xref:literaturextern:inhalt.adoc#litextern-spring-oauth2-bearertoken-resolver[offiziellen Spring Dokumentation].
 ====
 
-Um eine Klasse oder einzelne Methoden zu sichern, ist die `@Secured` Annotation des Bausteins Security zu verwendet.
+Um eine Klasse oder einzelne Methoden zu sichern, wird empfohlen, die `@Secured`-Annotation von Spring Security in der Service-Schicht zu verwenden.
+Die Verwendung auf einzelnen Webcontroller Klassen/Methoden wird nicht empfohlen.
+Für Webcontroller ohne Service Schicht kann https://docs.spring.io/spring-security/reference/servlet/authorization/authorize-http-requests.html[Request Level Autorisierung] genutzt werden.
 
 Generell ist das xref:isy-security:konzept/master.adoc#prinzipien-der-sicherheitsarchitektur[Konzept der Sicherheitsarchitektur] zu beachten.
 


### PR DESCRIPTION
* docs: IFS-2804 recommend usage of @Secured annotation at Service level
* feat: IFS-2804 remove @EnableMethodSecurity Annotation fom Autoconfiguration

    * describe required usage of @EnableMethodSecurity Annotation
    * describe usage of @PreAuthorize

* docs: IFS-2804 update migration guide