### PR TITLE
[Sprint 106] IFS-3833 Multi Tenancy in isy security 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `ISY-1040`: [isyfact-standards-doc] Anpassung des logback.xml-Konfigurationspfads im IF2-Migrationsleitfaden
 - `ISY-1061`: [isyfact-standards-doc] Ergänzung der Dokumentation zum Zurücksetzen der Korrelations-ID aus dem MdcHelper
 - `IFS-3665`: [isyfact-standards-doc] "Leitfaden Dokumentation" nach `isy-documentation` verschoben
+- `IFS-3833`: [isy-security] Implementierung von Multi-Tenanacy-Support
 
 # 3.0.1
 - `ISY-701`: Google Guava Versionsanhebung auf 33.1.0

--- a/isy-security/CHANGELOG.md
+++ b/isy-security/CHANGELOG.md
@@ -4,6 +4,7 @@
 - `ISY-980`: Anpassung der Dokumentation aufgrund von Security-Umstellungen
 - `IFS-2804`: `@EnableGlobalMethodSecurity` durch die modernere `@EnableMethodSecurity` Annotation ersetzt
   - Aktiviert standardmäßig @PreAuthorize, @PostAuthorize, @PreFilter und @PostFilter (`prePostEnabled = true`)
+- `IFS-3833`: Implementierung von Multi-Tenanacy-Support
 
 # 3.0.0
 

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/autoconfigure/IsySecurityAutoConfiguration.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/autoconfigure/IsySecurityAutoConfiguration.java
@@ -3,20 +3,38 @@ package de.bund.bva.isyfact.security.autoconfigure;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.lang.Nullable;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.core.GrantedAuthorityDefaults;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+import com.nimbusds.jwt.proc.JWTProcessor;
+
 import de.bund.bva.isyfact.security.authentication.RolePrivilegeGrantedAuthoritiesConverter;
+import de.bund.bva.isyfact.security.condition.TenantsNotEmptyCondition;
 import de.bund.bva.isyfact.security.config.IsySecurityConfigurationProperties;
+import de.bund.bva.isyfact.security.config.JWTConfigurationProperties;
 import de.bund.bva.isyfact.security.core.Berechtigungsmanager;
 import de.bund.bva.isyfact.security.core.IsyOAuth2Berechtigungsmanager;
 import de.bund.bva.isyfact.security.core.IsyOAuth2Security;
 import de.bund.bva.isyfact.security.core.Security;
+import de.bund.bva.isyfact.security.core.TenantJwsKeySelector;
+import de.bund.bva.isyfact.security.core.TenantJwtIssuerValidator;
 import de.bund.bva.isyfact.security.oauth2.client.Authentifizierungsmanager;
 import de.bund.bva.isyfact.security.xmlparser.RolePrivilegesMapper;
 
@@ -76,4 +94,46 @@ public class IsySecurityAutoConfiguration {
         return new IsyOAuth2Security(rolePrivilegesMapper, berechtigungsmanager, authentifizierungsmanager);
     }
 
+    /**
+     * Configuration for multi-tenancy support. This configuration is applied when the property
+     * "spring.security.oauth2.resourceserver.jwt.issuer-uri" is either set to "false" or not specified
+     * in the application properties, and tenant-specific configurations are provided in the application properties.
+     */
+    @Configuration
+    @ConditionalOnProperty(name = "spring.security.oauth2.resourceserver.jwt.issuer-uri", havingValue = "false", matchIfMissing = true)
+    @Conditional(TenantsNotEmptyCondition.class)
+    public static class MultiTenancyConfiguredDependentBeans {
+
+        @Bean
+        @ConfigurationProperties(prefix = "isy.security.oauth2.resourceserver.jwt")
+        public JWTConfigurationProperties jwtConfigurationProperties() {
+            return new JWTConfigurationProperties();
+        }
+
+        @Bean
+        public TenantJwsKeySelector tenantJwsKeySelector(JWTConfigurationProperties jwtConfigurationProperties) {
+            return new TenantJwsKeySelector(jwtConfigurationProperties);
+        }
+
+        @Bean
+        public TenantJwtIssuerValidator tenantJwtIssuerValidator(JWTConfigurationProperties jwtConfigurationProperties) {
+            return new TenantJwtIssuerValidator(jwtConfigurationProperties);
+        }
+
+        @Bean
+        JWTProcessor<SecurityContext> jwtProcessor(TenantJwsKeySelector keySelector) {
+            ConfigurableJWTProcessor<SecurityContext> jwtProcessor = new DefaultJWTProcessor<>();
+            jwtProcessor.setJWTClaimsSetAwareJWSKeySelector(keySelector);
+            return jwtProcessor;
+        }
+
+        @Bean
+        JwtDecoder jwtDecoder(JWTProcessor<SecurityContext> jwtProcessor, OAuth2TokenValidator<Jwt> jwtValidator) {
+            NimbusJwtDecoder decoder = new NimbusJwtDecoder(jwtProcessor);
+            OAuth2TokenValidator<Jwt> validator =
+                    new DelegatingOAuth2TokenValidator<>(JwtValidators.createDefault(), jwtValidator);
+            decoder.setJwtValidator(validator);
+            return decoder;
+        }
+    }
 }

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/condition/TenantsNotEmptyCondition.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/condition/TenantsNotEmptyCondition.java
@@ -1,0 +1,47 @@
+package de.bund.bva.isyfact.security.condition;
+
+import java.util.regex.Pattern;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.lang.NonNull;
+
+public class TenantsNotEmptyCondition implements Condition {
+
+    /**
+     * Pattern to match tenant issuer URI properties.
+     */
+    private static final Pattern TENANT_ISSUER_URI_PATTERN = Pattern.compile("isy\\.security\\.oauth2\\.resourceserver\\.jwt\\.tenants\\..+\\.issuer-uri");
+
+    @Override
+    public boolean matches(ConditionContext context, @NonNull AnnotatedTypeMetadata metadata) {
+        ConfigurableEnvironment env = (ConfigurableEnvironment) context.getEnvironment();
+        for (PropertySource<?> propertySource : env.getPropertySources()) {
+            if (propertySource instanceof EnumerablePropertySource) {
+                if (isTenantIssuerUriPresent((EnumerablePropertySource<?>) propertySource)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks if the tenant issuer URI is present in the given property source.
+     *
+     * @param propertySource the property source to check
+     * @return true if the tenant issuer URI is present, false otherwise
+     */
+    private boolean isTenantIssuerUriPresent(EnumerablePropertySource<?> propertySource) {
+        for (String propertyName : propertySource.getPropertyNames()) {
+            if (TENANT_ISSUER_URI_PATTERN.matcher(propertyName).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/config/JWTConfigurationProperties.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/config/JWTConfigurationProperties.java
@@ -1,0 +1,46 @@
+package de.bund.bva.isyfact.security.config;
+
+import java.util.Map;
+
+import org.springframework.validation.annotation.Validated;
+
+
+public class JWTConfigurationProperties {
+
+    /** The tenants. */
+    private Map<String, JwtServerProperties> tenants;
+
+    public Map<String, JwtServerProperties> getTenants() {
+        return tenants;
+    }
+
+    public void setTenants(Map<String, JwtServerProperties> tenants) {
+        this.tenants = tenants;
+    }
+
+    @Validated
+    public static class JwtServerProperties {
+
+        /** The issuer URI. */
+        private String issuerUri;
+
+        /** The JWK set URI. */
+        private String jwkSetUri;
+
+        public String getIssuerUri() {
+            return issuerUri;
+        }
+
+        public void setIssuerUri(String issuerUri) {
+            this.issuerUri = issuerUri;
+        }
+
+        public String getJwkSetUri() {
+            return jwkSetUri;
+        }
+
+        public void setJwkSetUri(String jwkSetUri) {
+            this.jwkSetUri = jwkSetUri;
+        }
+    }
+}

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/core/TenantJwsKeySelector.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/core/TenantJwsKeySelector.java
@@ -1,0 +1,82 @@
+package de.bund.bva.isyfact.security.core;
+
+import java.net.URL;
+import java.security.Key;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.KeySourceException;
+import com.nimbusds.jose.proc.JWSAlgorithmFamilyJWSKeySelector;
+import com.nimbusds.jose.proc.JWSKeySelector;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.JWTClaimsSetAwareJWSKeySelector;
+
+import de.bund.bva.isyfact.security.config.JWTConfigurationProperties;
+
+public class TenantJwsKeySelector implements JWTClaimsSetAwareJWSKeySelector<SecurityContext> {
+
+    /**
+     * The key selectors.
+     */
+    private final Map<String, JWSKeySelector<SecurityContext>> selectors = new ConcurrentHashMap<>();
+
+    /**
+     * The JWT properties.
+     */
+    private final JWTConfigurationProperties jwtProperties;
+
+    public TenantJwsKeySelector(JWTConfigurationProperties jwtProperties) {
+        this.jwtProperties = jwtProperties;
+    }
+
+    /**
+     * Select the JWS keys for a JWT.
+     *
+     * @param jwsHeader       the JWS header
+     * @param jwtClaimsSet    the JWT claims set
+     * @param securityContext the security context
+     * @return the JWS keys
+     * @throws KeySourceException if the keys cannot be selected
+     */
+    @Override
+    public List<? extends Key> selectKeys(JWSHeader jwsHeader, JWTClaimsSet jwtClaimsSet, SecurityContext securityContext)
+            throws KeySourceException {
+        return this.selectors.computeIfAbsent(toIssuer(jwtClaimsSet), this::fromIssuer)
+                .selectJWSKeys(jwsHeader, securityContext);
+    }
+
+    private String toIssuer(JWTClaimsSet claimSet) {
+        return claimSet.getIssuer();
+    }
+
+    /**
+     * Create a JWSKeySelector for a tenant.
+     *
+     * @param issuer the tenant
+     * @return the JWSKeySelector
+     */
+    private JWSKeySelector<SecurityContext> fromIssuer(String issuer) {
+        return jwtProperties.getTenants().values().stream()
+                .filter(tenant -> tenant.getIssuerUri().equals(issuer))
+                .findAny()
+                .map(tenant -> fromUri(tenant.getJwkSetUri()))
+                .orElseThrow(() -> new IllegalArgumentException("unknown tenant: " + issuer));
+    }
+
+    /**
+     * Create a JWSKeySelector from a JWKSet URI.
+     *
+     * @param uri the JWKSet URI
+     * @return the JWSKeySelector
+     */
+    private JWSKeySelector<SecurityContext> fromUri(String uri) {
+        try {
+            return JWSAlgorithmFamilyJWSKeySelector.fromJWKSetURL(new URL(uri));
+        } catch (Exception ex) {
+            throw new IllegalArgumentException(ex);
+        }
+    }
+}

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/core/TenantJwtIssuerValidator.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/core/TenantJwtIssuerValidator.java
@@ -1,0 +1,66 @@
+package de.bund.bva.isyfact.security.core;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtIssuerValidator;
+import org.springframework.stereotype.Component;
+
+import de.bund.bva.isyfact.security.config.JWTConfigurationProperties;
+
+@Component
+public class TenantJwtIssuerValidator implements OAuth2TokenValidator<Jwt> {
+
+    /** The JWT properties. */
+    private final JWTConfigurationProperties jwtProperties;
+
+    /** The validators. */
+    private final Map<String, JwtIssuerValidator> validators = new ConcurrentHashMap<>();
+
+    public TenantJwtIssuerValidator(JWTConfigurationProperties jwtProperties) {
+        this.jwtProperties = jwtProperties;
+    }
+
+    /**
+     * Validate the JWT.
+     *
+     * @param token
+     *         the token to validate
+     * @return the validation result
+     */
+    @Override
+    public OAuth2TokenValidatorResult validate(Jwt token) {
+        return validators.computeIfAbsent(toIssuer(token), this::fromIssuer)
+                .validate(token);
+    }
+
+    /**
+     * Get the issuer from a JWT.
+     *
+     * @param jwt
+     *         the JWT
+     * @return the tenant
+     */
+    private String toIssuer(Jwt jwt) {
+        return jwt.getIssuer().toString();
+    }
+
+    /**
+     * Create a JwtIssuerValidator for an issuer.
+     *
+     * @param issuer
+     *         the tenant
+     * @return the JwtIssuerValidator
+     */
+    private JwtIssuerValidator fromIssuer(String issuer) {
+        return jwtProperties.getTenants().values().stream()
+                .filter(tenant -> tenant.getIssuerUri().equals(issuer))
+                .findAny()
+                .map(JWTConfigurationProperties.JwtServerProperties::getIssuerUri)
+                .map(JwtIssuerValidator::new)
+                .orElseThrow(() -> new IllegalArgumentException("unknown tenant: " + issuer));
+    }
+}

--- a/isy-security/src/test/java/de/bund/bva/isyfact/security/authentication/ResourceServerMultiTenancyTest.java
+++ b/isy-security/src/test/java/de/bund/bva/isyfact/security/authentication/ResourceServerMultiTenancyTest.java
@@ -43,6 +43,10 @@ public class ResourceServerMultiTenancyTest {
 
     /**
      * Authentication and authorization via EmbeddedOidcProviderMock based on WireMock.
+     * A ping using a token from embeddedOidcProvider1 and embeddedOidcProvider2 is possible (tested in shouldAllowPingFromTestrealm1() and shouldAllowPingFromTestrealm2()),
+     *     as both tenants are defined in application-multi-tenancy.yaml.
+     * A ping with a token from embeddedOidcProvider3 fails as unauthorized (tested in shouldDenyPingFromTestrealm3())
+     *     since no matching tenant is defined in application-multi-tenancy.yaml.
      */
     @RegisterExtension
     public static final EmbeddedOidcProviderMock embeddedOidcProvider1 = new EmbeddedOidcProviderMock(HOST, PORT1, ISSUER_PATH1);

--- a/isy-security/src/test/java/de/bund/bva/isyfact/security/authentication/ResourceServerMultiTenancyTest.java
+++ b/isy-security/src/test/java/de/bund/bva/isyfact/security/authentication/ResourceServerMultiTenancyTest.java
@@ -1,0 +1,121 @@
+package de.bund.bva.isyfact.security.authentication;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import de.bund.bva.isyfact.security.IsySecurityTestConfiguration;
+import de.bund.bva.isyfact.security.example.config.SecurityConfig;
+import de.bund.bva.isyfact.security.example.rest.ExampleRestController;
+import de.bund.bva.isyfact.security.test.oidcprovider.EmbeddedOidcProviderMock;
+
+@ActiveProfiles("multi-tenancy")
+@SpringBootTest(classes = {
+        IsySecurityTestConfiguration.class, SecurityConfig.class, ExampleRestController.class
+}, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@EnableAutoConfiguration
+public class ResourceServerMultiTenancyTest {
+
+    protected static final String ISSUER_PATH1 = "/auth/realms/testrealm1";
+    protected static final String ISSUER_PATH2 = "/auth/realms/testrealm2";
+    protected static final String ISSUER_PATH3 = "/auth/realms/testrealm3";
+
+    private static final String HOST = "localhost";
+
+    private static final int PORT1 = 9095;
+    private static final int PORT2 = 9096;
+    private static final int PORT3 = 9097;
+
+    /**
+     * Authentication and authorization via EmbeddedOidcProviderMock based on WireMock.
+     */
+    @RegisterExtension
+    public static final EmbeddedOidcProviderMock embeddedOidcProvider1 = new EmbeddedOidcProviderMock(HOST, PORT1, ISSUER_PATH1);
+    @RegisterExtension
+    public static final EmbeddedOidcProviderMock embeddedOidcProvider2 = new EmbeddedOidcProviderMock(HOST, PORT2, ISSUER_PATH2);
+    @RegisterExtension
+    public static final EmbeddedOidcProviderMock embeddedOidcProvider3 = new EmbeddedOidcProviderMock(HOST, PORT3, ISSUER_PATH3);
+    @LocalServerPort
+    private int port;
+
+    private String pingUri;
+
+    @BeforeEach
+    public void setup() {
+        embeddedOidcProvider1.removeAllClients();
+        embeddedOidcProvider2.removeAllClients();
+        embeddedOidcProvider3.removeAllClients();
+        pingUri = "http://localhost:" + port + "/ping";
+    }
+
+    /**
+     * Test with an issuer that is configured as a tenant in the resource server configuration.
+     */
+    @Test
+    public void shouldAllowPingFromTestrealm1() {
+        // manually get a token signed by the OIDC provider
+        String token = embeddedOidcProvider1.getAccessTokenString("cc-client", "testuser", Optional.empty(),
+                Collections.singleton("Rolle_A"));
+
+        String body = WebClient.create().get().uri(pingUri)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                .exchangeToMono(response -> {
+                    assertEquals(HttpStatus.OK, response.statusCode());
+                    return response.bodyToMono(String.class);
+                }).block();
+
+        assertEquals("true", body);
+
+    }
+
+    /**
+     * Test with an issuer that is configured as a tenant in the resource server configuration.
+     */
+    @Test
+    public void shouldAllowPingFromTestrealm2() {
+        // manually get a token signed by the OIDC provider
+        String token = embeddedOidcProvider2.getAccessTokenString("cc-client", "testuser", Optional.empty(),
+                Collections.singleton("Rolle_A"));
+
+        String body = WebClient.create().get().uri(pingUri)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                .exchangeToMono(response -> {
+                    assertEquals(HttpStatus.OK, response.statusCode());
+                    return response.bodyToMono(String.class);
+                }).block();
+
+        assertEquals("true", body);
+        verify(0, getRequestedFor(urlMatching(ISSUER_PATH2 + ".*")));
+    }
+
+    @Test
+    public void shouldDenyPingFromTestrealm3() {
+        // manually get a token signed by the OIDC provider
+        String token = embeddedOidcProvider3.getAccessTokenString("cc-client", "testuser", Optional.empty(),
+                Collections.singleton("Rolle_A"));
+
+        WebClient.create().get().uri(pingUri)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                .exchangeToMono(response -> {
+                    // status 401 Unauthorized expected as the tenant was not set
+                    assertEquals(HttpStatus.UNAUTHORIZED, response.statusCode());
+                    return response.bodyToMono(String.class);
+                }).block();
+    }
+
+}

--- a/isy-security/src/test/java/de/bund/bva/isyfact/security/autoconfigure/IsySecurityAutoConfigurationTest.java
+++ b/isy-security/src/test/java/de/bund/bva/isyfact/security/autoconfigure/IsySecurityAutoConfigurationTest.java
@@ -1,6 +1,7 @@
 package de.bund.bva.isyfact.security.autoconfigure;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeAll;
@@ -14,13 +15,19 @@ import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.core.GrantedAuthorityDefaults;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+
+import com.nimbusds.jwt.proc.JWTProcessor;
 
 import de.bund.bva.isyfact.security.AbstractOidcProviderTest;
 import de.bund.bva.isyfact.security.config.IsyOAuth2ClientConfigurationProperties;
 import de.bund.bva.isyfact.security.config.IsySecurityConfigurationProperties;
+import de.bund.bva.isyfact.security.config.JWTConfigurationProperties;
 import de.bund.bva.isyfact.security.core.Berechtigungsmanager;
 import de.bund.bva.isyfact.security.core.Security;
+import de.bund.bva.isyfact.security.core.TenantJwsKeySelector;
+import de.bund.bva.isyfact.security.core.TenantJwtIssuerValidator;
 import de.bund.bva.isyfact.security.oauth2.client.Authentifizierungsmanager;
 import de.bund.bva.isyfact.security.oauth2.client.annotation.AuthenticateInterceptor;
 import de.bund.bva.isyfact.security.oauth2.client.authentication.ClientCredentialsAuthorizedClientAuthenticationProvider;
@@ -255,19 +262,67 @@ public class IsySecurityAutoConfigurationTest extends AbstractOidcProviderTest {
     }
 
     @Test
+    public void testContextStartsWithoutMultiTenancy() {
+        contextRunner
+                .withPropertyValues(
+                        "spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:9095/auth/realms/testrealm")
+                .run(context -> assertThat(context)
+                        .hasNotFailed()
+                        .doesNotHaveBean(JWTConfigurationProperties.class)
+                        .doesNotHaveBean(TenantJwsKeySelector.class)
+                        .doesNotHaveBean(TenantJwtIssuerValidator.class)
+                        .doesNotHaveBean(JwtDecoder.class)
+                        .doesNotHaveBean(JWTProcessor.class)
+                );
+    }
+
+    @Test
+    public void testContextStartsWithoutMultiTenancyWithMultiTenancyProperties() {
+        contextRunner
+                .withPropertyValues(
+                        "spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:9095/auth/realms/testrealm",
+                        "isy.security.oauth2.resourceserver.jwt.tenants.tenant1.issuer-uri=http://localhost:9095/auth/realms/testrealm1",
+                        "isy.security.oauth2.resourceserver.jwt.tenants.tenant1.jwks-uri=http://localhost:9096/auth/realms/testrealm1")
+                .run(context -> assertThat(context)
+                        .hasNotFailed()
+                        .doesNotHaveBean(JWTConfigurationProperties.class)
+                        .doesNotHaveBean(TenantJwsKeySelector.class)
+                        .doesNotHaveBean(TenantJwtIssuerValidator.class)
+                        .doesNotHaveBean(JwtDecoder.class)
+                        .doesNotHaveBean(JWTProcessor.class)
+                );
+    }
+
+    @Test
+    public void testContextStartsWithMultiTenancySpringPropertyMissing() {
+        contextRunner
+                .withPropertyValues(
+                        "isy.security.oauth2.resourceserver.jwt.tenants.tenant1.issuer-uri=http://localhost:9095/auth/realms/testrealm1",
+                        "isy.security.oauth2.resourceserver.jwt.tenants.tenant1.jwks-uri=http://localhost:9096/auth/realms/testrealm1")
+                .run(context -> assertThat(context)
+                        .hasNotFailed()
+                        .hasSingleBean(JWTConfigurationProperties.class)
+                        .hasSingleBean(TenantJwsKeySelector.class)
+                        .hasSingleBean(TenantJwtIssuerValidator.class)
+                        .hasSingleBean(JwtDecoder.class)
+                        .hasSingleBean(JWTProcessor.class)
+                );
+    }
+
+    @Test
     void isySecurityAutoConfigurationNoMappingFile() {
         contextRunner
-            .withPropertyValues(
-                "isy.security.role-privileges-mapping-file=/resources/sicherheit/noRollenrechte.xml"
-            )
-            .run(context -> {
-                    assertThat(context)
-                        .hasNotFailed()
-                        .hasSingleBean(RolePrivilegesMapper.class);
+                .withPropertyValues(
+                        "isy.security.role-privileges-mapping-file=/resources/sicherheit/noRollenrechte.xml"
+                )
+                .run(context -> {
+                            assertThat(context)
+                                    .hasNotFailed()
+                                    .hasSingleBean(RolePrivilegesMapper.class);
 
-                    RolePrivilegesMapper mapper = context.getBean(RolePrivilegesMapper.class);
-                    assertThat(mapper.getAllPrivileges()).isEmpty();
-                }
-            );
+                            RolePrivilegesMapper mapper = context.getBean(RolePrivilegesMapper.class);
+                            assertThat(mapper.getAllPrivileges()).isEmpty();
+                        }
+                );
     }
 }

--- a/isy-security/src/test/resources/application-multi-tenancy.yaml
+++ b/isy-security/src/test/resources/application-multi-tenancy.yaml
@@ -1,0 +1,12 @@
+isy:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          tenants:
+            tenant1:
+              issuer-uri: http://localhost:9095/auth/realms/testrealm1
+              jwk-set-uri: http://localhost:9095/auth/realms/testrealm1/protocol/openid-connect/certs
+            tenant2:
+              issuer-uri: http://localhost:9096/auth/realms/testrealm2
+              jwk-set-uri: http://localhost:9096/auth/realms/testrealm2/protocol/openid-connect/certs

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/inhalt.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/inhalt.adoc
@@ -391,6 +391,39 @@ Der in `isy.security.roles-claim-name` konfigurierte Wert unterstützt keine Ver
 Es ist sicherzustellen, dass das konfigurierte Roles-Claim auch vom Identity Provider befüllt werden.
 ====
 
+[[konfiguration-von-multi-tenancy]]
+=== Konfiguration von Multi-Tenancy
+Für die Unterstützung von Multi-Tenancy ist es erforderlich, die Eigenschaft `spring.security.oauth2.resourceserver.jwt.issuer-uri` zu deaktivieren (auf `false` setzen) oder zu entfernen. Die nachstehenden Konfigurationsparameter werden zur Einstellung von Multi-Tenancy verwendet. Aus Gründen der Übersichtlichkeit wird das Präfix `isy.security.oauth2` in der unten aufgeführten Tabelle weggelassen.
+
+[[table-parameter-multi-tenancy]]
+.Konfigurationsparameter für Multi-Tenancy
+[cols="3m,2m,2m,8",options="header"]
+|===
+|Parameter |Wertebereich |Default |Beschreibung
+|resourceserver.jwt.tenants.<tenant>.issuer-uri  |String |_keiner_ | URI des Ausstellers des JWT, spezifisch für den Tenant
+|resourceserver.jwt.tenants.<tenant>.jwk-set-uri  |String |_keiner_ |URI des JWK-Sets, das die öffentlichen Schlüssel bereitstellt, welche zur Validierung der JWT-Signatur verwendet werden
+|===
+
+Nachfolgend ist eine Beispielkonfiguration für Multi-Tenancy dargestellt.
+
+:desc-listing-multi-tenancy-configuration-example: Multi-Tenancy Beispiel Konfiguration
+[id="listing-multi-tenancy-configuration-example",reftext="{listing-caption} {counter:listings}"]
+.{desc-listing-multi-tenancy-configuration-example}
+[source,properties="verbatim,attributes"]
+----
+
+isy.security.oauth2.resourceserver.jwt.tenants.tenant-1.issuer-uri=http(s)://<keycloak-host>:<keycloak-port>/auth/realms/<keycloak-realm-1> <1>
+isy.security.oauth2.resourceserver.jwt.tenants.tenant-1.jwk-set-uri=http(s)://<keycloak-host>:<keycloak-port>/auth/realms/<keycloak-realm-1>/protocol/openid-connect/certs <2>
+
+isy.security.oauth2.resourceserver.jwt.tenants.tenant-2.jwk-set-uri=http(s)://<keycloak-host>:<keycloak-port>/auth/realms/<keycloak-realm-2> <3>
+isy.security.oauth2.resourceserver.jwt.tenants.tenant-2.jwk-set-uri=http(s)://<keycloak-host>:<keycloak-port>/auth/realms/<keycloak-realm-2>/protocol/openid-connect/certs <4>
+----
+
+<1> URI des Ausstellers des JWT für tenant-1, z.B. die Authentifizierungs-URL von Keycloak für das Realm `<keycloak-realm-1>`.
+<2> URI des JWK-Sets für tenant-1, das die öffentlichen Schlüssel enthält, die zur Validierung der JWT-Signatur verwendet werden.
+<3> URI des Ausstellers des JWT für tenant-2, z.B. die Authentifizierungs-URL von Keycloak für das Realm `<keycloak-realm-2>`.
+<4> URI des JWK-Sets für tenant-2, das die öffentlichen Schlüssel enthält, die zur Validierung der JWT-Signatur verwendet werden.
+
 [[konfiguration-von-rollen-und-rechten]]
 === Konfiguration von Rollen und Rechten
 


### PR DESCRIPTION
* feat: IFS-3833 add custom JwsKeySelector, JwtIssuerValidator and JWTConfigurationProperties for multitenancy
* feat: IFS-3833 adjust IsyAutoConfiguration for multitenancy support
* test: IFS-3833 extend tests for multitenancy support
* docs: IFS-3833 add an entry for multi-tenancy support in the documentation
* chore: IFS-3833 update changelogs