### PR TITLE
Docs build template for triggering documentation build

### DIFF
--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -1,14 +1,12 @@
-name: Build Documentation
+name: Documentation Build
+
 on:
   push:
     tags:
-      - '\d+.\d+.\d+'
+      - '^\\d+\\.\\d+\\.\\d+$'
 
 jobs:
-  TriggerBuild:
-    runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ secrets.ANTORA_TRIGGER_TOKEN }}
-    steps:
-      - name: Trigger documentation build
-        run: gh workflow run antora_build.yml -R IsyFact/isyfact.github.io
+  DocsBuild:
+    uses:  IsyFact/isy-github-actions-templates/.github/workflows/docs_build_template.yml@v1.4.0
+    secrets:
+      ANTORA_TRIGGER_TOKEN: ${{ secrets.ANTORA_TRIGGER_TOKEN }}


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Updated the documentation build workflow to use a reusable template from `IsyFact/isy-github-actions-templates`.
- Changed the workflow name to `Documentation Build`.
- Modified the tag pattern to correctly match semantic versioning.
- Configured secrets for the reusable workflow.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docs_build.yml</strong><dd><code>Update documentation build workflow to use reusable template</code></dd></summary>
<hr>

.github/workflows/docs_build.yml

<li>Changed workflow name from <code>Build Documentation</code> to <code>Documentation Build</code>.<br> <li> Updated tag pattern for triggering the workflow.<br> <li> Replaced custom job steps with a reusable workflow template.<br> <li> Added secrets configuration for the reusable workflow.<br>


</details>


  </td>
  <td><a href="https://github.com/IsyFact/isyfact-standards/pull/509/files#diff-edb6672fa7dcb9af0bd76fda78ae452099603775ec3b666b17f092e055d92588">+7/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

