### PR TITLE
[Sprint 109] IFS-3938_Release_IsyFact_3.1.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ include:
     file: 'Maven.gitlab-ci.yml'
 
 variables:
-  NEXT_VERSION: 3.0.0
+  NEXT_VERSION: 3.1.0
 
 default:
   image: $REPOSITORY_IFS_DOCKER/isy-build-maven:3-openjdk17-alpine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,21 +5,24 @@
 - `IFS-3612`: [isy-aufrufkontext] als deprecated markiert
 - `ISY-948`: Spring Cache Abstraction als verpflichtende Bibliothek für anwendungsseitige Caches eingeführt
 - `ISY-305`: [isy-security] Implementierung von IsySecurityTokenUtil zum Auslesen von Attributen aus dem Bearer Token
+- `ISY-980`: [isy-security] Anpassung der Dokumentation aufgrund von Security-Umstellungen
 - `ISY-1040`: [isyfact-standards-doc] Anpassung des logback.xml-Konfigurationspfads im IF2-Migrationsleitfaden
 - `ISY-1061`: [isyfact-standards-doc] Ergänzung der Dokumentation zum Zurücksetzen der Korrelations-ID aus dem MdcHelper
 - `IFS-3665`: [isyfact-standards-doc] "Leitfaden Dokumentation" nach `isy-documentation` verschoben
 - `IFS-3821`: [isyfact-standards-doc] Thematik zur internen und externen URL bei der Authentifizierung beschrieben (Multiple Issuer-URIs)
 - `IFS-3834`: [isyfact-standards-doc] Kapitel Authentifizierung & Autorisierung um Multi-Tenancy erweitert.
-- `IFS-3833`: [isy-security] Implementierung von Multi-Tenanacy-Support
+- `IFS-2804`: [isy-security] `@EnableGlobalMethodSecurity` durch die modernere `@EnableMethodSecurity` Annotation ersetzt 
+- `IFS-3833`: [isy-security] Implementierung von Multi-Tenancy-Support
+- `IFS-2591`: [isyfact-products-bom] Spring Security Versionsanhebung auf 5.8.13
 - `IFS-2248`: [isy-batchrahmen, isy-security] Tokenerneuerung in isy-batchrahmen:
   * `IsySecurityTokenUtil` und `IsyOAuth2Authentifizierungsmanager` stellen Funktionalität zur Token-Gültigkeitsüberprüfung und erneuten Authentifizierung bereit
   * Funktionalität zur erneuten Authentifizierung wird von `BatchrahmenImpl` aufgerufen
 - `IFS-3763`: [isyfact-standards-doc] Dokumentation der Änderungen zu IFS-2248 (Tokenerneuerung isy-batchrahmen)
 - `IFS-3051`: [isyfact-standards-doc] Kapitel zu Multi-Realms um konkrete Vorgabe erweitert.
+- `IFS-3938`: IsyFact Versionsanhebung auf 3.1.0
 
 ### Bug Fixes
 - `IFS-3871`: [isy-serviceapi-core] Vermeidet ClassCastException in TimeoutWiederholungHttpInvokerRequestExecutor bei Nutzung von AufrufkontextVerwalter
-
 
 # 3.0.1
 - `ISY-701`: Google Guava Versionsanhebung auf 33.1.0

--- a/isy-security/CHANGELOG.md
+++ b/isy-security/CHANGELOG.md
@@ -4,7 +4,7 @@
 - `ISY-980`: Anpassung der Dokumentation aufgrund von Security-Umstellungen
 - `IFS-2804`: `@EnableGlobalMethodSecurity` durch die modernere `@EnableMethodSecurity` Annotation ersetzt
   - Aktiviert standardmäßig @PreAuthorize, @PostAuthorize, @PreFilter und @PostFilter (`prePostEnabled = true`)
-- `IFS-3833`: Implementierung von Multi-Tenanacy-Support
+- `IFS-3833`: Implementierung von Multi-Tenancy-Support
 - `IFS-2248`: Bereitstellen von Funktionalität zur Token-Gültigkeitsüberprüfung und erneuten Authentifizierung
 
 # 3.0.0

--- a/isyfact-standards-doc/pom.xml
+++ b/isyfact-standards-doc/pom.xml
@@ -46,7 +46,7 @@
                         <configuration>
                             <outputDirectory>${project.build.directory}</outputDirectory>
                             <attributes>
-                                <revnumber>IsyFact 3.0.x</revnumber>
+                                <revnumber>IsyFact 3.1.x</revnumber>
                                 <revdate>${maven.build.timestamp}</revdate>
                             </attributes>
                         </configuration>

--- a/isyfact-standards-doc/src/docs/antora/antora.yml
+++ b/isyfact-standards-doc/src/docs/antora/antora.yml
@@ -1,7 +1,7 @@
 name: isyfact-standards-doku
 title: IsyFact Standards
 version: '3.1.x'
-display_version: '3.1 (DEV)'
+display_version: '3.1 (CURRENT)'
 prerelease: true
 start_page: einstieg:einstieg.adoc
 nav:

--- a/isyfact-standards-doc/src/docs/antora/modules/blaupausen/pages/detailkonzept-komponente-batch/changelog.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/blaupausen/pages/detailkonzept-komponente-batch/changelog.adoc
@@ -1,6 +1,14 @@
 [[changelog]]
 = Changelog
 
+*Änderungen IsyFact 3.1.0*
+
+// tag::release-3.1.0[]
+
+- `IFS-3763`: Dokumentation der Änderungen zu IFS-2248 (Tokenerneuerung isy-batchrahmen)
+
+// end::release-3.1.0[]
+
 // *Änderungen IsyFact 3.0.0*
 
 // tag::release-3.0.0[]

--- a/isyfact-standards-doc/src/docs/antora/modules/blaupausen/pages/referenzarchitektur/changelog.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/blaupausen/pages/referenzarchitektur/changelog.adoc
@@ -1,6 +1,14 @@
 [[changelog]]
 = Changelog
 
+*Änderungen IsyFact 3.1.0*
+
+// tag::release-3.1.0[]
+
+* `IFS-3992`: Entfernung der Vorlage "Tailoring" Dokument
+
+// end::release-3.1.0[]
+
 *Änderungen IsyFact 3.0.0*
 
 // tag::release-3.0.0[]

--- a/isyfact-standards-doc/src/docs/antora/modules/changelog/pages/changelog.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/changelog/pages/changelog.adoc
@@ -2,8 +2,25 @@
 
 == Änderungen IsyFact 3.1.0
 
-- Isy-Konfiguration wurde als deprecated gekennzeichnet
-- Dokumentation: Externe Verweise (`literaturextern`) von `isy-documentation` nach `isyfact-standards` verschoben.
+- Anhebung der Versionen mehrerer Abhängigkeiten der IsyFact und durch den Produktkatalog vorgegebenen Abhängigkeiten.
+
+=== Änderungen im Produktkatalog
+
+include::isyfact-standards-doku:einstieg:page$produktkatalog/changelog.adoc[tag=release-3.1.0]
+
+=== Änderungen Bausteine
+
+- `IFS-3612`: `isy-aufrufkontext` wurde als deprecated gekennzeichnet
+- `IFS-3665`: Dokumentation: Externe Verweise (`literaturextern`) von `isy-documentation` nach `isyfact-standards` verschoben
+include::isyfact-standards-doku:isy-konfiguration:page$konzept/changelog.adoc[tag=release-3.1.0]
+include::isyfact-standards-doku:isy-security:page$konzept/changelog.adoc[tag=release-3.1.0]
+include::isyfact-standards-doku:isy-security:page$nutzungsvorgaben/changelog.adoc[tag=release-3.1.0]
+include::isyfact-standards-doku:isy-service-rest:page$konzept/../changelog.adoc[tag=release-3.1.0]
+
+=== Änderungen Blaupausen
+
+include::isyfact-standards-doku:blaupausen:page$referenzarchitektur/changelog.adoc[tag=release-3.1.0]
+include::isyfact-standards-doku:blaupausen:page$detailkonzept-komponente-batch/changelog.adoc[tag=release-3.1.0]
 
 == Änderungen IsyFact 3.0.1
 

--- a/isyfact-standards-doc/src/docs/antora/modules/einstieg/pages/produktkatalog/changelog.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/einstieg/pages/produktkatalog/changelog.adoc
@@ -1,6 +1,15 @@
 [[changelog]]
 = Changelog
 
+*Änderungen IsyFact 3.1.0*
+
+// tag::release-3.1.0[]
+* Anhebung von Versionen:
+
+** Spring Security auf 5.8.13
+
+// end::release-3.1.0[]
+
 *Änderungen IsyFact 3.0.1*
 
 // tag::release-3.0.1[]

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-konfiguration/pages/konzept/changelog.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-konfiguration/pages/konzept/changelog.adoc
@@ -1,6 +1,14 @@
 [[changelog]]
 = Changelog
 
+// *Änderungen IsyFact 3.1.0*
+
+// tag::release-3.1.0[]
+
+- `ISY-808`: `isy-konfiguration` wurde als deprecated gekennzeichnet
+
+// end::release-3.1.0[]
+
 // *Änderungen IsyFact 3.0.0*
 
 // tag::release-3.0.0[]

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/konzept/changelog.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/konzept/changelog.adoc
@@ -9,6 +9,8 @@
 - `IFS-3834`: `isy-security`: Kapitel Authentifizierung & Autorisierung um Multi-Tenancy erweitert.
 - `IFS-3051`: `isy-security`: Kapitel zu Multi-Realms um konkrete Vorgabe erweitert.
 
+// end::release-3.1.0[]
+
 *Änderungen IsyFact 3.0.0*
 
 // tag::release-3.0.0[]

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/changelog.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/changelog.adoc
@@ -1,6 +1,14 @@
 [[changelog]]
 = Changelog
 
+*Änderungen IsyFact 3.1.0*
+
+// tag::release-3.1.0[]
+
+- `IFS-3763`: Dokumentation der Änderungen zu IFS-2248 (Tokenerneuerung isy-batchrahmen)
+
+// end::release-3.1.0[]
+
 *Änderungen IsyFact 3.0.0*
 
 // tag::release-3.0.0[]

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-service-rest/pages/changelog.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-service-rest/pages/changelog.adoc
@@ -1,10 +1,10 @@
 [[changelog]]
 = Changelog
 
-*Änderungen IsyFact 3.0.0*
+*Änderungen IsyFact 3.1.0*
 
-// tag::release-3.0.0[]
+// tag::release-3.1.0[]
 
-- `ISY-1061`: Ergänzung der Dokumentation zum Zurücksetzen der Korrelations-ID aus dem MdcHelper
+- `ISY-1061`: `isy-service-rest` Ergänzung der Dokumentation zum Zurücksetzen der Korrelations-ID aus dem MdcHelper
 
-// end::release-3.0.0[]
+// end::release-3.1.0[]


### PR DESCRIPTION
Tag "3.1.0" has to be added in release/3.x branch after PR-approval (required for succesfull documentation build via [isyfact.github.io](https://github.com/IsyFact/isyfact.github.io))