### PR TITLE
chore: IFS-4031 updated enforced maven version to 3.6.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 
         <!-- maven-enforcer-plugin configuration -->
         <enforced.jdk.version>[17,18)</enforced.jdk.version>
-        <enforced.maven.version>[3.1.1,4)</enforced.maven.version>
+        <enforced.maven.version>[3.6.3,4)</enforced.maven.version>
 
         <!-- Property is set by jacoco and user by surefire -->
         <maven.jacoco.argLine/>


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated the enforced Maven version in the `pom.xml` file to ensure compatibility with Maven version 3.6.3 and above.
- This change is part of the Maven Enforcer Plugin configuration to maintain build consistency and compatibility.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pom.xml</strong><dd><code>Update enforced Maven version to 3.6.3</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pom.xml

<li>Updated the enforced Maven version to 3.6.3 in the Maven Enforcer <br>Plugin configuration.<br>


</details>


  </td>
  <td><a href="https://github.com/IsyFact/isyfact-standards/pull/528/files#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

