### PR TITLE
[Sprint 110] IFS-1629 standard absicherung endpoints 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 3.2.0
 ### Features
+- `IFS-1629`: Standardmechanismus zur Absicherung der Actuator Endpunkte auf Basis von WebSecurityConfigurerAdapter bereitgestellt. Aktivieren durch setzen der Konfigurationsparameter:
+    * `isy.ueberwachung.security.username=<username>`
+    * `isy.ueberwachung.security.password=<password>`
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 3.2.0
 ### Features
-- `IFS-1629`: Standardmechanismus zur Absicherung der Actuator Endpunkte auf Basis von WebSecurityConfigurerAdapter bereitgestellt. Aktivieren durch setzen der Konfigurationsparameter:
+- `IFS-1629`: Standardmechanismus zur Absicherung der Actuator-Endpunkte auf Basis von WebSecurityConfigurerAdapter wurde bereitgestellt. Aktivieren durch das Setzen der Konfigurationsparameter:
     * `isy.ueberwachung.security.username=<username>`
     * `isy.ueberwachung.security.password=<password>`
 

--- a/isy-ueberwachung/CHANGELOG.md
+++ b/isy-ueberwachung/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 3.2.0
 ### Features
-- `IFS-1629`: Standardmechanismus zur Absicherung der Actuator Endpunkte auf Basis von WebSecurityConfigurerAdapter bereitgestellt. Aktivieren durch setzen der Konfigurationsparameter:
+- `IFS-1629`: Standardmechanismus zur Absicherung der Actuator-Endpunkte auf Basis von WebSecurityConfigurerAdapter wurde bereitgestellt. Aktivieren durch das Setzen der Konfigurationsparameter:
     * `isy.ueberwachung.security.username=<username>`
     * `isy.ueberwachung.security.password=<password>`
 

--- a/isy-ueberwachung/CHANGELOG.md
+++ b/isy-ueberwachung/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.2.0
+### Features
+- `IFS-1629`: Standardmechanismus zur Absicherung der Actuator Endpunkte auf Basis von WebSecurityConfigurerAdapter bereitgestellt. Aktivieren durch setzen der Konfigurationsparameter:
+    * `isy.ueberwachung.security.username=<username>`
+    * `isy.ueberwachung.security.password=<password>`
+
 # 3.0.0
 - `IFS-1702`: Refaktorierung ServiceStatistik
     * Entkoppelt von Micrometer API

--- a/isy-ueberwachung/pom.xml
+++ b/isy-ueberwachung/pom.xml
@@ -144,6 +144,11 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/isy-ueberwachung/pom.xml
+++ b/isy-ueberwachung/pom.xml
@@ -146,7 +146,7 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/autoconfigure/IsyActuatorSecurityAutoConfiguration.java
+++ b/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/autoconfigure/IsyActuatorSecurityAutoConfiguration.java
@@ -1,0 +1,88 @@
+package de.bund.bva.isyfact.ueberwachung.autoconfigure;
+
+import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+import de.bund.bva.isyfact.ueberwachung.config.ActuatorSecurityConfigurationProperties;
+
+/**
+ * Configures HttpBasic authentication for actuator endpoints.
+ */
+@Configuration
+@ConditionalOnClass({SecurityFilterChain.class, HttpSecurity.class})
+public class IsyActuatorSecurityAutoConfiguration {
+
+    /** Enpoint role to identify the actuator Enpoint Admin. */
+    public static final String ENDPOINT_ROLE = "ENDPOINT_ADMIN";
+
+    /**
+     * Security Properties.
+     *
+     * @return {@link ActuatorSecurityConfigurationProperties}
+     */
+    @Bean
+    @ConfigurationProperties(prefix = "isy.ueberwachung.security")
+    public ActuatorSecurityConfigurationProperties actuatorSecurityConfigurationProperties() {
+        return new ActuatorSecurityConfigurationProperties();
+    }
+
+    /**
+     * Password encoder for in memory authentication.
+     *
+     * @return {@link BCryptPasswordEncoder}
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnProperty("isy.ueberwachung.security.username")
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Configuration
+    @Order(1)
+    @ConditionalOnProperty("isy.ueberwachung.security.username")
+    public static class HttpBasicWebEndpointSecurityConfiguration extends WebSecurityConfigurerAdapter {
+        /**
+         * Monitoring user configuration.
+         */
+        private final ActuatorSecurityConfigurationProperties properties;
+
+        /**
+         * Password encoder implementation.
+         */
+        private final PasswordEncoder passwordEncoder;
+
+        public HttpBasicWebEndpointSecurityConfiguration(ActuatorSecurityConfigurationProperties properties, PasswordEncoder passwordEncoder) {
+            this.properties = properties;
+            this.passwordEncoder = passwordEncoder;
+        }
+
+        @Override
+        protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+            auth.inMemoryAuthentication()
+                .withUser(properties.getUsername())
+                .password(passwordEncoder.encode(properties.getPassword()))
+                .roles(ENDPOINT_ROLE);
+        }
+
+        @Override
+        protected void configure(HttpSecurity http) throws Exception {
+            http.requestMatcher(EndpointRequest.toAnyEndpoint())
+                .authorizeHttpRequests(requests -> requests.anyRequest().hasRole(ENDPOINT_ROLE))
+                .httpBasic();
+        }
+    }
+
+}

--- a/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/autoconfigure/IsyActuatorSecurityAutoConfiguration.java
+++ b/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/autoconfigure/IsyActuatorSecurityAutoConfiguration.java
@@ -18,13 +18,13 @@ import org.springframework.security.web.SecurityFilterChain;
 import de.bund.bva.isyfact.ueberwachung.config.ActuatorSecurityConfigurationProperties;
 
 /**
- * Configures HttpBasic authentication for actuator endpoints.
+ * Configures Http Basic Authentication for actuator endpoints.
  */
 @Configuration
 @ConditionalOnClass({SecurityFilterChain.class, HttpSecurity.class})
 public class IsyActuatorSecurityAutoConfiguration {
 
-    /** Enpoint role to identify the actuator Enpoint Admin. */
+    /** Endpoint role to identify the Actuator Endpoint Admin. */
     public static final String ENDPOINT_ROLE = "ENDPOINT_ADMIN";
 
     /**
@@ -39,7 +39,7 @@ public class IsyActuatorSecurityAutoConfiguration {
     }
 
     /**
-     * Password encoder for in memory authentication.
+     * Password encoder for in-memory authentication.
      *
      * @return {@link BCryptPasswordEncoder}
      */

--- a/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/config/ActuatorSecurityConfigurationProperties.java
+++ b/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/config/ActuatorSecurityConfigurationProperties.java
@@ -1,0 +1,32 @@
+package de.bund.bva.isyfact.ueberwachung.config;
+
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Contains properties to configure a monitoring user.
+ */
+@Validated
+public class ActuatorSecurityConfigurationProperties {
+
+    /** Username for HTTP access to actuator endpoints. Can be {@code Null} but must not be empty. */
+    private String username;
+
+    /** Password for HTTP access to actuator endpoints. */
+    private String password;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/isy-ueberwachung/src/main/resources/META-INF/spring.factories
+++ b/isy-ueberwachung/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,5 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
   de.bund.bva.isyfact.ueberwachung.autoconfigure.IsyUeberwachungAutoConfiguration,\
   de.bund.bva.isyfact.ueberwachung.autoconfigure.IsyHealthAutoConfiguration,\
-  de.bund.bva.isyfact.ueberwachung.autoconfigure.IsyMetricsAutoConfiguration
+  de.bund.bva.isyfact.ueberwachung.autoconfigure.IsyMetricsAutoConfiguration,\
+  de.bund.bva.isyfact.ueberwachung.autoconfigure.IsyActuatorSecurityAutoConfiguration  

--- a/isy-ueberwachung/src/test/java/de/bund/bva/isyfact/ueberwachung/actuate/health/HealthIntegrationTest.java
+++ b/isy-ueberwachung/src/test/java/de/bund/bva/isyfact/ueberwachung/actuate/health/HealthIntegrationTest.java
@@ -1,5 +1,9 @@
 package de.bund.bva.isyfact.ueberwachung.actuate.health;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -20,7 +24,7 @@ import org.springframework.boot.actuate.health.Status;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.ResourceBundleMessageSource;
@@ -34,24 +38,21 @@ import de.bund.bva.isyfact.ueberwachung.actuate.health.nachbarsystemcheck.model.
 import de.bund.bva.isyfact.ueberwachung.autoconfigure.IsyHealthAutoConfiguration;
 import de.bund.bva.isyfact.util.spring.MessageSourceHolder;
 
-import static de.bund.bva.isyfact.ueberwachung.actuate.health.HealthIntegrationTest.DELAY_MS;
-import static org.junit.Assert.*;
-
 /**
  * Class for verifying whether the health endpoint functions correctly with the caching registry.
  */
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = { IsyHealthAutoConfiguration.class, HealthIntegrationTest.TestConfiguration.class },
-        properties = {
-                "isy.logging.anwendung.name=HealthIntegrationTest",
-                "isy.logging.anwendung.version=1.0.0-SNAPSHOT",
-                "isy.logging.anwendung.typ=Integrationstest"
-        },
-        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(classes = {IsyHealthAutoConfiguration.class, HealthIntegrationTest.TestConfiguration.class},
+    properties = {
+        "isy.logging.anwendung.name=HealthIntegrationTest",
+        "isy.logging.anwendung.version=1.0.0-SNAPSHOT",
+        "isy.logging.anwendung.typ=Integrationstest",
+    },
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @EnableAutoConfiguration(exclude = {
-        SecurityAutoConfiguration.class,
-        ManagementWebSecurityAutoConfiguration.class
+    SecurityAutoConfiguration.class,
+    ManagementWebSecurityAutoConfiguration.class
 })
 public class HealthIntegrationTest {
 

--- a/isy-ueberwachung/src/test/java/de/bund/bva/isyfact/ueberwachung/actuate/health/nachbarsystemcheck/impl/NachbarsystemCheckImplWithServerMockTest.java
+++ b/isy-ueberwachung/src/test/java/de/bund/bva/isyfact/ueberwachung/actuate/health/nachbarsystemcheck/impl/NachbarsystemCheckImplWithServerMockTest.java
@@ -30,10 +30,10 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.SocketPolicy;
 
-public class NachbarsystemCheckImplTestWithServerMock {
+public class NachbarsystemCheckImplWithServerMockTest {
 
     private final IsyLogger LOGGER =
-            IsyLoggerFactory.getLogger(NachbarsystemCheckImplTestWithServerMock.class);
+            IsyLoggerFactory.getLogger(NachbarsystemCheckImplWithServerMockTest.class);
 
     private static MockWebServer mockBackEnd;
 

--- a/isy-ueberwachung/src/test/java/de/bund/bva/isyfact/ueberwachung/autoconfigure/IsyActuatorSecurityAutoConfigurationTest.java
+++ b/isy-ueberwachung/src/test/java/de/bund/bva/isyfact/ueberwachung/autoconfigure/IsyActuatorSecurityAutoConfigurationTest.java
@@ -1,0 +1,77 @@
+package de.bund.bva.isyfact.ueberwachung.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+class IsyActuatorSecurityAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner(AnnotationConfigApplicationContext::new)
+        .withConfiguration(AutoConfigurations.of(
+            IsyUeberwachungAutoConfiguration.class,
+            IsyActuatorSecurityAutoConfiguration.class
+        ));
+
+    @Test
+    void noUserConfigured() {
+        contextRunner.run(context ->
+            assertThat(context).hasNotFailed()
+                .hasSingleBean(IsyActuatorSecurityAutoConfiguration.class)
+                // WebSecurityConfigurerAdapter and PasswordEncoder not created
+                .doesNotHaveBean(IsyActuatorSecurityAutoConfiguration.HttpBasicWebEndpointSecurityConfiguration.class)
+                .doesNotHaveBean(PasswordEncoder.class)
+        );
+    }
+
+    @Test
+    void userWithoutPasswordConfigured() {
+        contextRunner
+            .withPropertyValues(
+                "isy.ueberwachung.security.username=test",
+                // empty/null password should work
+                "isy.ueberwachung.security.password="
+            ).run(context ->
+                assertThat(context).hasNotFailed()
+                    .hasSingleBean(IsyActuatorSecurityAutoConfiguration.class)
+                    .hasSingleBean(IsyActuatorSecurityAutoConfiguration.HttpBasicWebEndpointSecurityConfiguration.class)
+                    .hasSingleBean(PasswordEncoder.class)
+            );
+    }
+
+    @Test
+    void passwordWithoutUserConfigured() {
+        contextRunner
+            .withPropertyValues(
+                // username must not be empty => BindValidationException.class
+                "isy.ueberwachung.security.username=    ",
+                "isy.ueberwachung.security.password=test"
+            ).run(context ->
+                assertThat(context).hasFailed().getFailure()
+                    .getRootCause()
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .message()
+                    .isEqualTo("Cannot pass null or empty values to constructor")
+            );
+    }
+
+    @Test
+    void disabledWithDisabledSecurity() {
+        // bean not available
+        contextRunner
+            .withClassLoader(new FilteredClassLoader(HttpSecurity.class))
+            .run(context -> assertThat(context)
+                .hasNotFailed()
+                .doesNotHaveBean(IsyActuatorSecurityAutoConfiguration.class)
+                .doesNotHaveBean(AuthenticationConfiguration.class)
+                .doesNotHaveBean(WebSecurityConfiguration.class)
+            );
+    }
+}

--- a/isy-ueberwachung/src/test/java/de/bund/bva/isyfact/ueberwachung/autoconfigure/IsyActuatorSecurityAutoConfigurationTest.java
+++ b/isy-ueberwachung/src/test/java/de/bund/bva/isyfact/ueberwachung/autoconfigure/IsyActuatorSecurityAutoConfigurationTest.java
@@ -12,6 +12,12 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+/**
+ * Tests for {@link IsyActuatorSecurityAutoConfiguration}.
+ * <p>
+ * Tests the behavior of the AutoConfiguration, depending on the property (application.properties)
+ * and dependency (pom.xml) configuration.
+ */
 class IsyActuatorSecurityAutoConfigurationTest {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner(AnnotationConfigApplicationContext::new)
@@ -20,6 +26,10 @@ class IsyActuatorSecurityAutoConfigurationTest {
             IsyActuatorSecurityAutoConfiguration.class
         ));
 
+    /**
+     * No user configured, so no security should be applied.
+     * (avoids a breaking change in IF3 applications)
+     */
     @Test
     void noUserConfigured() {
         contextRunner.run(context ->
@@ -31,6 +41,9 @@ class IsyActuatorSecurityAutoConfigurationTest {
         );
     }
 
+    /**
+     * User configured, so security should be applied.
+     */
     @Test
     void userWithoutPasswordConfigured() {
         contextRunner
@@ -46,6 +59,9 @@ class IsyActuatorSecurityAutoConfigurationTest {
             );
     }
 
+    /**
+     * Password without user configured. Username must not be empty.
+     */
     @Test
     void passwordWithoutUserConfigured() {
         contextRunner
@@ -62,6 +78,9 @@ class IsyActuatorSecurityAutoConfigurationTest {
             );
     }
 
+    /**
+     * Assuming Spring Security is not on the classpath, so security must not be applied.
+     */
     @Test
     void disabledWithDisabledSecurity() {
         // bean not available

--- a/isy-ueberwachung/src/test/java/de/bund/bva/isyfact/ueberwachung/config/LoadbalancerSecurityBeanConfigurationTest.java
+++ b/isy-ueberwachung/src/test/java/de/bund/bva/isyfact/ueberwachung/config/LoadbalancerSecurityBeanConfigurationTest.java
@@ -14,7 +14,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration;
 import org.springframework.security.web.SecurityFilterChain;
 
-import de.bund.bva.isyfact.ueberwachung.autoconfigure.IsyHealthAutoConfiguration;
 import de.bund.bva.isyfact.ueberwachung.autoconfigure.IsyUeberwachungAutoConfiguration;
 
 public class LoadbalancerSecurityBeanConfigurationTest {

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-ueberwachung/pages/nutzungsvorgaben/inhalt.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-ueberwachung/pages/nutzungsvorgaben/inhalt.adoc
@@ -328,46 +328,29 @@ isy.task.tasks.isyHealthTask.fixed-delay=30s
 ===== Absicherung von Endpoints
 
 Der Zugriff auf Endpoints muss mit einer Authentifizierung abgesichert werden.
-Eine Konfiguration für Spring Security, die alle Endpoints mit HTTP Basic Authentication absichert,
-zeigt <<listing-endpointsecurityconfig>>.
-Der Benutzername und das Passwort werden in `application.properties` gepflegt.
+Eine Standard-Konfiguration für Spring Security, die alle Endpoints mit HTTP Basic Authentication absichert, wird durch die Klasse `IsyActuatorSecurityAutoConfiguration` bereitgestellt.
 
+Standardmäßig wird der Zugriff auf Endpoints durch eine HTTP Basic Authentifizierung aktiviert, wenn die *Dependencies*:
 
-.Absicherung der Endpoints mit Spring Security
-[id="listing-endpointsecurityconfig",reftext="{listing-caption} {counter:listings }"]
-[source,java]
+* `org.springframework.security:spring-security-config` und
+* `org.springframework.security:spring-security-web`
+
+im Klassenpfad verfügbar sind und *Benutzername* sowie *Passwort* zum Zugriff auf die Endpoints in der `application.properties` konfiguriert sind (siehe <<listing-endpoint-security-properties>>).
+Ohne Konfiguration von Benutzername und Passwort ist die Absicherung nicht aktiv.
+
+.Konfiguration der Absicherung in `application.properties`
+[id="listing-endpoint-security-properties",reftext="{listing-caption} {counter:listings }"]
+[source,properties]
 ----
-@Configuration
-@EnableWebSecurity
-@Profile("produktion")
-public class ActuatorSecurityProduktionConfig extends WebSecurityConfigurerAdapter {
-
-    @Autowired
-    private UeberwachungSecurityConfigProperties properties;
-
-    private static final String ENDPOINT_ROLE = "ENDPOINT_ADMIN";
-
-    @Override
-    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
-         auth.inMemoryAuthentication()
-             .withUser(properties.getUsername())
-             .password(passwordEncoder().encode(properties.getPassword()))
-             .roles(ENDPOINT_ROLE);
-    }
-
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-        http.requestMatcher(EndpointRequest.toAnyEndpoint())
-                .authorizeHttpRequests(requests -> requests.anyRequest().hasRole(ENDPOINT_ROLE))
-                .httpBasic();
-    }
-
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
-}
+# Benutzername des Monitoring Users (Default: null)
+isy.ueberwachung.security.username=<username>
+# Passwort des Monitoring Users (Default: null)
+isy.ueberwachung.security.password=<password>
 ----
+
+Die Standardabsicherung der Endpoints kann per Konfiguration von der Spring AutoConfiguration ausgeschlossen und überschrieben werden, falls die Anforderungen der Anwendung von der Standardabsicherung abweichen:
+
+`spring.autoconfigure.exclude=de.bund.bva.isyfact.ueberwachung.autoconfigure.IsyActuatorSecurityAutoConfiguration`
 
 [[abschalten-der-absicherung-fuer-die-entwicklung]]
 ====== Abschalten der Absicherung für die Entwicklung

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-ueberwachung/pages/nutzungsvorgaben/inhalt.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-ueberwachung/pages/nutzungsvorgaben/inhalt.adoc
@@ -328,14 +328,14 @@ isy.task.tasks.isyHealthTask.fixed-delay=30s
 ===== Absicherung von Endpoints
 
 Der Zugriff auf Endpoints muss mit einer Authentifizierung abgesichert werden.
-Eine Standard-Konfiguration für Spring Security, die alle Endpoints mit HTTP Basic Authentication absichert, wird durch die Klasse `IsyActuatorSecurityAutoConfiguration` bereitgestellt.
+Eine Standardkonfiguration für Spring Security, die alle Endpunkte mit HTTP Basic Authentication absichert, wird durch die Klasse `IsyActuatorSecurityAutoConfiguration` bereitgestellt.
 
-Standardmäßig wird der Zugriff auf Endpoints durch eine HTTP Basic Authentifizierung aktiviert, wenn die *Dependencies*:
+Standardmäßig wird der Zugriff auf Endpunkte durch eine HTTP Basic Authentifizierung aktiviert, wenn die *Dependencies*:
 
 * `org.springframework.security:spring-security-config` und
 * `org.springframework.security:spring-security-web`
 
-im Klassenpfad verfügbar sind und *Benutzername* sowie *Passwort* zum Zugriff auf die Endpoints in der `application.properties` konfiguriert sind (siehe <<listing-endpoint-security-properties>>).
+im Klassenpfad verfügbar sind und *Benutzername* sowie *Passwort* zum Zugriff auf die Endpunkte in der `application.properties` konfiguriert sind (siehe <<listing-endpoint-security-properties>>).
 Ohne Konfiguration von Benutzername und Passwort ist die Absicherung nicht aktiv.
 
 .Konfiguration der Absicherung in `application.properties`
@@ -348,7 +348,7 @@ isy.ueberwachung.security.username=<username>
 isy.ueberwachung.security.password=<password>
 ----
 
-Die Standardabsicherung der Endpoints kann per Konfiguration von der Spring AutoConfiguration ausgeschlossen und überschrieben werden, falls die Anforderungen der Anwendung von der Standardabsicherung abweichen:
+Die Standardabsicherung der Endpunkte kann per Konfiguration von der Spring AutoConfiguration ausgeschlossen und überschrieben werden, falls die Anforderungen der Anwendung von der Standardabsicherung abweichen:
 
 `spring.autoconfigure.exclude=de.bund.bva.isyfact.ueberwachung.autoconfigure.IsyActuatorSecurityAutoConfiguration`
 


### PR DESCRIPTION
* feat(ueberwachung): IFS-1629 provide security properties
* feat(ueberwachung): IFS-1629 add IsyActuatorSecurityAutoConfiguration
* test(ueberwachung): IFS-1629: rename test to get picked up by surefire plugin
* docs(ueberwachung): IFS-1629 update Dokumentation

    * update CHANGELOG.md