### PR TITLE
[Sprint 110] IFS-2395 messageSourceHolder 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - `IFS-1629`: Standardmechanismus zur Absicherung der Actuator-Endpunkte auf Basis von WebSecurityConfigurerAdapter wurde bereitgestellt. Aktivieren durch das Setzen der Konfigurationsparameter:
     * `isy.ueberwachung.security.username=<username>`
     * `isy.ueberwachung.security.password=<password>`
+- `IFS-2395`: [isy-util] `MessageSourceHolder` sowie `MessageSourceFehlertextProvider` als deprecated markiert
 
 ### Bug Fixes
 

--- a/isy-util/CHANGELOG.md
+++ b/isy-util/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.2.0
+- `IFS-2395`: `MessageSourceHolder` sowie `MessageSourceFehlertextProvider` als deprecated markiert
+
 # 2.4.0
 - `RF-1040`: Scope für Spotbugs-Annotations Abhängigkeit auf provided gesetzt
 

--- a/isy-util/src/main/java/de/bund/bva/isyfact/util/common/RecursiveToStringBuilder.java
+++ b/isy-util/src/main/java/de/bund/bva/isyfact/util/common/RecursiveToStringBuilder.java
@@ -30,6 +30,11 @@ import java.util.Map.Entry;
  * This class generates a text output for objects that do not implement a suitable toString method.
  */
 public class RecursiveToStringBuilder {
+
+    private RecursiveToStringBuilder () {
+        // hide the constructor as it is a utility class
+    }
+
     /**
      * Maximum number of java primitive type entries from an array that will appear in output.
      */

--- a/isy-util/src/main/java/de/bund/bva/isyfact/util/common/RecursiveToStringBuilder.java
+++ b/isy-util/src/main/java/de/bund/bva/isyfact/util/common/RecursiveToStringBuilder.java
@@ -27,21 +27,19 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 /**
- * Diese Klasse erzeugt eine Textausgabe für Objekte, die keine geeignete toString-Methode implementieren.
- *
+ * This class generates a text output for objects that do not implement a suitable toString method.
  */
 public class RecursiveToStringBuilder {
     /**
-     * Maximal Anzahl der java primitivtyp Einträge aus einer Array die in Ausgabe erscheinen wird.
+     * Maximum number of java primitive type entries from an array that will appear in output.
      */
     private static final int PRIMITIVE_ARRAY_MAX_OUTPUT_SIZE = 16;
 
     /**
-     * Rekursive Ausgabe von Objekten.
+     * Recursive output of objects.
      *
-     * @param o
-     *            Das auszugebende Objekt
-     * @return Das ausgegebende Objekt
+     * @param o The object to be output
+     * @return The object to be output
      */
     public static String recursiveToString(final Object o) {
         final StringBuilder buffer = new StringBuilder();
@@ -52,16 +50,12 @@ public class RecursiveToStringBuilder {
     }
 
     /**
-     * Rekursive Ausgabe von Objekten.
+     * Recursive output of objects.
      *
-     * @param prefix
-     *            Das Ausgabe-Präfix
-     * @param o
-     *            Das zu schreibende Objekt
-     * @param buffer
-     *            Der StringBuilder
-     * @param seen
-     *            Rückreferenzen
+     * @param prefix The output prefix
+     * @param o The object to be written
+     * @param buffer The StringBuilder
+     * @param seen Backreferences
      */
     private static void recursiveToString(final StringBuilder prefix, final Object o,
         final StringBuilder buffer, final Collection<Object> seen) {
@@ -100,16 +94,12 @@ public class RecursiveToStringBuilder {
     }
 
     /**
-     * Hinzufügen Stringdarstellung von Array-Objekt.
+     * Add string representation of array object.
      *
-     * @param prefix
-     *            Das Ausgabe-Präfix
-     * @param o
-     *            Das zu schreibende Array-Objekt
-     * @param buffer
-     *            Der StringBuilder
-     * @param seen
-     *            Rückreferenzen
+     * @param prefix The output prefix
+     * @param o The array object to be written
+     * @param buffer The StringBuilder
+     * @param seen references
      */
     private static void appendArray(final StringBuilder prefix, final Object o, final StringBuilder buffer,
         final Collection<Object> seen) {
@@ -149,16 +139,12 @@ public class RecursiveToStringBuilder {
     }
 
     /**
-     * Hinzufügen Stringdarstellung von Iterable-Objekt.
+     * Add string representation of Iterable object.
      *
-     * @param prefix
-     *            Das Ausgabe-Präfix
-     * @param o
-     *            Das zu schreibende Iterable-Objekt
-     * @param buffer
-     *            Der StringBuilder
-     * @param seen
-     *            Rückreferenzen
+     * @param prefix The output prefix
+     * @param o The iterable object to be written
+     * @param buffer The StringBuilder
+     * @param seen references
      */
     private static void appendIterable(final StringBuilder prefix, final Iterable<?> o,
         final StringBuilder buffer, final Collection<Object> seen) {
@@ -177,16 +163,12 @@ public class RecursiveToStringBuilder {
     }
 
     /**
-     * Hinzufügen Stringdarstellung von Map-Objekt.
+     * Add string representation of map object.
      *
-     * @param prefix
-     *            Das Ausgabe-Präfix
-     * @param o
-     *            Das zu schreibende Map-Objekt
-     * @param buffer
-     *            Der StringBuilder
-     * @param seen
-     *            Rückreferenzen
+     * @param prefix The output prefix
+     * @param o The map object to be written
+     * @param buffer The StringBuilder
+     * @param seen references
      */
     private static void appendMap(final StringBuilder prefix, final Map<?, ?> o, final StringBuilder buffer,
         final Collection<Object> seen) {
@@ -211,16 +193,12 @@ public class RecursiveToStringBuilder {
 
 
     /**
-     * Hinzufügen Stringdarstellung des Objekts.
+     * Add string representation of the object.
      *
-     * @param prefix
-     *            Das Ausgabe-Präfix
-     * @param o
-     *            Das zu schreibende Objekt
-     * @param buffer
-     *            Der StringBuilder
-     * @param seen
-     *            Rückreferenzen
+     * @param prefix The output prefix
+     * @param o The object to be written
+     * @param buffer The StringBuilder
+     * @param seen references
      */
     private static void appendGeneric(final StringBuilder prefix, final Object o, final StringBuilder buffer,
         final Collection<Object> seen) {
@@ -230,7 +208,7 @@ public class RecursiveToStringBuilder {
         buffer.append("{");
         buffer.append('\n');
 
-        // Bestimme alle Felder - auch die der vererbendene Klassen
+        // Determine all fields - including those of the inheriting classes
         Field[] fields = bestimmeAlleFelder(o);
 
         for (final Field field : fields) {
@@ -254,11 +232,10 @@ public class RecursiveToStringBuilder {
     }
 
     /**
-     * ermittelt alle Felder eines übergenenen Objekts.
+     * Determines all fields of a superordinate object.
      *
-     * @param o
-     *            Das Objekt
-     * @return Alle Felder.
+     * @param o The object
+     * @return All fields.
      */
     private static Field[] bestimmeAlleFelder(Object o) {
         List<Field> fields = new LinkedList<>();
@@ -273,12 +250,10 @@ public class RecursiveToStringBuilder {
     }
 
     /**
-     * ermittelt ob ein Objekt rekursiv ausgegeben werden soll.
+     * determines whether an object is to be output recursively.
      *
-     * @param o
-     *            Das zu prüfende Objekt
-     * @return <code>true</code> falls das Objekt nit rekursiv ausgegeben werden soll, ansonsten
-     *         <code>false</code>
+     * @param o The object to be checked
+     * @return {@code true} if the object is not to be output recursively, otherwise {@code false}
      */
     private static boolean shouldNotRecurse(final Object o) {
         try {
@@ -299,12 +274,10 @@ public class RecursiveToStringBuilder {
     }
 
     /**
-     * schreibt ein Objekt.
+     * writes an object.
      *
-     * @param o
-     *            Das zu schreibende Objekt
-     * @param buffer
-     *            Der StringBuilder der für die Ausgabe verwendet werden soll
+     * @param o The object to be written
+     * @param buffer The StringBuilder to be used for the output
      */
     private static void objectToString(final Object o, final StringBuilder buffer) {
         buffer.append(o.getClass().getName());

--- a/isy-util/src/main/java/de/bund/bva/isyfact/util/exception/MessageSourceFehlertextProvider.java
+++ b/isy-util/src/main/java/de/bund/bva/isyfact/util/exception/MessageSourceFehlertextProvider.java
@@ -23,15 +23,10 @@ import de.bund.bva.isyfact.exception.FehlertextProvider;
 import de.bund.bva.isyfact.util.spring.MessageSourceHolder;
 
 /**
- * Diese Klasse implementiert einen {@link FehlertextProvider}, der zum Laden der Nachrichten den
- * {@link MessageSourceHolder} verwendet. Letztere muss als Spring-Bean in der Anwendung konfiguriert sein.
- * 
+ * This class implements a {@link FehlertextProvider} that uses the {@link MessageSourceHolder} to load the messages (must be configured as a Spring bean in the application).
  */
 public class MessageSourceFehlertextProvider implements FehlertextProvider {
 
-    /**
-     * {@inheritDoc}
-     */
     public String getMessage(String schluessel, String... parameter) {
         return MessageSourceHolder.getMessage(schluessel, parameter);
     }

--- a/isy-util/src/main/java/de/bund/bva/isyfact/util/exception/MessageSourceFehlertextProvider.java
+++ b/isy-util/src/main/java/de/bund/bva/isyfact/util/exception/MessageSourceFehlertextProvider.java
@@ -31,6 +31,7 @@ import de.bund.bva.isyfact.util.spring.MessageSourceHolder;
 @Deprecated
 public class MessageSourceFehlertextProvider implements FehlertextProvider {
 
+    @Override
     public String getMessage(String schluessel, String... parameter) {
         return MessageSourceHolder.getMessage(schluessel, parameter);
     }

--- a/isy-util/src/main/java/de/bund/bva/isyfact/util/exception/MessageSourceFehlertextProvider.java
+++ b/isy-util/src/main/java/de/bund/bva/isyfact/util/exception/MessageSourceFehlertextProvider.java
@@ -24,7 +24,11 @@ import de.bund.bva.isyfact.util.spring.MessageSourceHolder;
 
 /**
  * This class implements a {@link FehlertextProvider} that uses the {@link MessageSourceHolder} to load the messages (must be configured as a Spring bean in the application).
+ *
+ * @deprecated as of IsyFact 3, due to the deprecation of {@link MessageSourceHolder}, an application must implement {@link FehlertextProvider} itself if required (without {@link  MessageSourceHolder}).
+ * Class will be deleted in future version.
  */
+@Deprecated
 public class MessageSourceFehlertextProvider implements FehlertextProvider {
 
     public String getMessage(String schluessel, String... parameter) {

--- a/isy-util/src/main/java/de/bund/bva/isyfact/util/spring/MessageSourceHolder.java
+++ b/isy-util/src/main/java/de/bund/bva/isyfact/util/spring/MessageSourceHolder.java
@@ -25,10 +25,17 @@ import org.springframework.context.NoSuchMessageException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
- * This class holds a reference to the current MessageSource bean.
+ * This class holds a reference to the current {@link MessageSource} bean.
  * <p>
- * In addition, it offers convenience functions for reading resource bundle entries from the MessageSource.
+ * In addition, it offers convenience functions for reading resource bundle entries from the {@link MessageSource}.
+ *
+ * <p><b>WARNING: Due to the static implementation, it can happen that hints, events and error messages are not resolved correctly.
+ *
+ * @deprecated as of IsyFact 3 in favour of Spring's {@link MessageSource} bean.
+ * Applications should provide a {@link MessageSource} bean with a unique name (indicating the originating application).
+ * Class will be deleted in future version.
  */
+@Deprecated
 public final class MessageSourceHolder implements MessageSourceAware {
 
     /** Static reference to the MessageSource of the application. */
@@ -38,7 +45,7 @@ public final class MessageSourceHolder implements MessageSourceAware {
      * Reads a message from the resource bundles configured in Spring.
      *
      * @param schluessel the key of the resource bundle
-     * @param parameter the value for the placeholders to be replaced
+     * @param parameter  the value for the placeholders to be replaced
      * @return the message
      */
     public static String getMessage(String schluessel, String... parameter) {
@@ -49,8 +56,8 @@ public final class MessageSourceHolder implements MessageSourceAware {
      * Reads a message from the resource bundles configured in Spring.
      *
      * @param schluessel the key of the resource bundle
-     * @param parameter the value for the placeholders to be replaced
-     * @param locale the language of the message
+     * @param parameter  the value for the placeholders to be replaced
+     * @param locale     the language of the message
      * @return the message
      */
     public static String getMessage(String schluessel, Locale locale, String... parameter) {
@@ -77,10 +84,7 @@ public final class MessageSourceHolder implements MessageSourceAware {
      *
      * @param messageSource MessageSource-Bean of the application.
      */
-    @SuppressFBWarnings(
-            value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD",
-            justification = "Solved with IFS-805"
-    )
+    @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", justification = "Solved with IFS-805")
     public void setMessageSource(MessageSource messageSource) {
         MessageSourceHolder.messageSource = messageSource;
     }

--- a/isy-util/src/main/java/de/bund/bva/isyfact/util/spring/MessageSourceHolder.java
+++ b/isy-util/src/main/java/de/bund/bva/isyfact/util/spring/MessageSourceHolder.java
@@ -18,46 +18,40 @@ package de.bund.bva.isyfact.util.spring;
 
 import java.util.Locale;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.context.MessageSource;
 import org.springframework.context.MessageSourceAware;
 import org.springframework.context.NoSuchMessageException;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
- * Diese Klasse hält eine Referenz auf die aktuelle MessageSource-Bean.
+ * This class holds a reference to the current MessageSource bean.
  * <p>
- * Zusätzlich bietet sie Convenience-Funktionen zum Auslesen von Resourcebundle- Einträgen aus der
- * MessageSource.
- * 
+ * In addition, it offers convenience functions for reading resource bundle entries from the MessageSource.
  */
 public final class MessageSourceHolder implements MessageSourceAware {
 
-    /** Statischer Verweis auf die MessageSource der Anwendung. */
+    /** Static reference to the MessageSource of the application. */
     private static MessageSource messageSource;
 
     /**
-     * Liest eine Nachricht aus den in Spring konfigurierten Resource-Bundles aus.
-     * 
-     * @param schluessel
-     *            der Schlüssel des Resource-Bundles
-     * @param parameter
-     *            der Wert fuer die zu ersetzenden Platzhalter
-     * @return die Nachricht
+     * Reads a message from the resource bundles configured in Spring.
+     *
+     * @param schluessel the key of the resource bundle
+     * @param parameter the value for the placeholders to be replaced
+     * @return the message
      */
     public static String getMessage(String schluessel, String... parameter) {
         return getMessage(schluessel, Locale.GERMANY, parameter);
     }
 
     /**
-     * Liest eine Nachricht aus den in Spring konfigurierten Resource-Bundles aus.
-     * 
-     * @param schluessel
-     *            der Schlüssel des Resource-Bundles
-     * @param parameter
-     *            der Wert für die zu ersetzenden Platzhalter
-     * @param locale
-     *            die Sprache der Nachricht
-     * @return die Nachricht
+     * Reads a message from the resource bundles configured in Spring.
+     *
+     * @param schluessel the key of the resource bundle
+     * @param parameter the value for the placeholders to be replaced
+     * @param locale the language of the message
+     * @return the message
      */
     public static String getMessage(String schluessel, Locale locale, String... parameter) {
         try {
@@ -79,10 +73,9 @@ public final class MessageSourceHolder implements MessageSourceAware {
     }
 
     /**
-     * Setter für Spring.
-     * 
-     * @param messageSource
-     *            MessageSource-Bean der Anwendung.
+     * Setter for Spring.
+     *
+     * @param messageSource MessageSource-Bean of the application.
      */
     @SuppressFBWarnings(
             value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD",

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-util/pages/nutzungsvorgaben/inhalt.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-util/pages/nutzungsvorgaben/inhalt.adoc
@@ -38,7 +38,7 @@ include::glossary:miscellaneous:partial$deprecated-abschnitt.adoc[]
 ****
 *Anmerkung zur Deprecation*
 
-Für die Benennung der `MessageSource`-Bean wird empfohlen, einen eindeutiger Namen zu wählen, damit diese via Spring-Boardmittel überschrieben werden kann.
+Für die Benennung der `MessageSource`-Bean wird empfohlen, einen eindeutigeren Namen zu wählen, damit diese mittels Spring-Bordmitteln überschrieben werden kann.
 ****
 
 Das Package `de.bund.bva.isyfact.util.spring` enthält Werkzeuge für den Umgang mit Spring:

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-util/pages/nutzungsvorgaben/inhalt.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-util/pages/nutzungsvorgaben/inhalt.adoc
@@ -15,6 +15,15 @@ Zurzeit besteht sie aus folgender Klasse:
 [[package-exception]]
 === Package exception
 
+:linkaktuell: xref:isy-exception-core:nutzungsvorgaben/inhalt.adoc#fehlertextprovider[FehlertextProvider]
+include::glossary:miscellaneous:partial$deprecated-abschnitt.adoc[]
+
+****
+*Anmerkung zur Deprecation*
+
+Für Fehlermeldungen wird empfohlen, das Interface `de.bund.bva.isyfact.exception.FehlertextProvider` zu implementieren.
+****
+
 In `de.bund.bva.isyfact.util.exception` sind Klassen enthalten, die für die Fehlerbehandlung einzusetzen sind:
 
 * `MessageSourceFehlertextProvider`: Durch diese Klasse wird der `FehlertextProvider` implementiert, der sich im Package `de.bund.bva.isyfact.exception` der xref:glossary:glossary:master.adoc#glossar-bibliothek[Bibliothek] isy-exception-core befindet.
@@ -22,6 +31,15 @@ Der `FehlertextProvider` beschreibt Methoden zum Auslesen von Fehlertexten auf B
 
 [[package-spring]]
 === Package spring
+
+:linkaktuell: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/MessageSource.html[org.springframework.context.MessageSource]
+include::glossary:miscellaneous:partial$deprecated-abschnitt.adoc[]
+
+****
+*Anmerkung zur Deprecation*
+
+Für die Benennung der `MessageSource`-Bean wird empfohlen, einen eindeutiger Namen zu wählen, damit diese via Spring-Boardmittel überschrieben werden kann.
+****
 
 Das Package `de.bund.bva.isyfact.util.spring` enthält Werkzeuge für den Umgang mit Spring:
 


### PR DESCRIPTION
* chore(util): IFS-2395 translates javadoc
* feat(util): IFS-2395 makes RecursiveToStringBuilder constructor private
* docs(util): IFS-2395 adds deprecation for MessageSourceHolder and MessageSourceFehlertextProvider
* feat(util): IFS-2395 adds override annotation in MessageSourceFehlertextProvider
* feat: IFS-2395 adds entry to CHANGELOG.md