### PR TITLE
[Sprint 111] IFS-4010 persistence autoconfiguration documentation if3

### DIFF
--- a/isy-persistence/pom.xml
+++ b/isy-persistence/pom.xml
@@ -123,8 +123,18 @@
             <artifactId>spring-boot-test-autoconfigure</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/isy-persistence/src/test/java/de/bund/bva/isyfact/persistence/autoconfigure/IsyPersistenceAutoConfigurationTest.java
+++ b/isy-persistence/src/test/java/de/bund/bva/isyfact/persistence/autoconfigure/IsyPersistenceAutoConfigurationTest.java
@@ -58,7 +58,7 @@ class IsyPersistenceAutoConfigurationTest {
     }
 
     @Test
-    void expectCyclicReferenceException() {
+    void testExpectCyclicReferenceException() {
         assertThatThrownBy(() ->
             new SpringApplicationBuilder()
                 .sources(TestConfig.class)
@@ -69,7 +69,7 @@ class IsyPersistenceAutoConfigurationTest {
     }
 
     @Test
-    void validAutoConfiguration() {
+    void testValidAutoConfiguration() {
         Map<String, Object> properties = new HashMap<>();
 
         properties.put("isy.logging.anwendung.name", "test");

--- a/isyfact-standards-doc/src/docs/antora/modules/changelog/pages/migrationsleitfaden.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/changelog/pages/migrationsleitfaden.adoc
@@ -520,6 +520,12 @@ Die Änderungen der Methodensignaturen sind in den nachfolgenden Tabellen beschr
 
 |===
 
+[[kapitel-persistence]]
+=== Persistence
+In IsyFact 3 werden `DataSourceProperties` von Spring Boot verwendet und lediglich um die Attribute `schemaVersion` und `schemaInvalidVersionAction` erweitert.
+Hierdurch haben sich die Namen der Konfigurationsschlüssel geändert und müssen angepasst werden.
+Details zur Konfiguration sind in den xref:isy-persistence:nutzungsvorgaben/konfiguration.adoc#konfiguration-der-datasource[Nutzungsvorgaben Persistence] zu finden.
+
 [[kapitel-dokumentation]]
 == Dokumentation
 

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-persistence/pages/nutzungsvorgaben/konfiguration.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-persistence/pages/nutzungsvorgaben/konfiguration.adoc
@@ -48,13 +48,13 @@ Als Datasource-Implementierung muss die Implementierung aus `de.bund.bva.isyfact
 Bei der Verwendung von `isy-persistence` wird automatisch eine Bean mit dem Namen `appDataSource` erzeugt.
 Diese prüft die Version des Datenbankschemas (siehe Abschnitt xref:nutzungsvorgaben/versionierung.adoc#pruefen-der-schemaversion[Prüfen der Schema-Version]) und dient als Wrapper für die eigentliche Spring `DataSource`.
 
-Die Autokonfiguration der IsyFact 3 Version von `isy-persistence` verwendet Spring Boot Meachnismen, um die `DataSource` zu konfigurieren.
-Unter dem Prefix `isy.persistence.datasource` können alle Properties konfiguriert werden, welche in Spring unter dem Prefix `spring.datasource` bekannt sind (vgl. link:https://docs.spring.io/spring-boot/appendix/application-properties/index.html#appendix.application-properties.data[Common Application Properties]).
+Die Autokonfiguration der IsyFact 3 Version von `isy-persistence` verwendet Spring Boot Mechanismen, um die `DataSource` zu konfigurieren.
+Unter dem Präfix `isy.persistence.datasource` können alle Properties konfiguriert werden, welche in Spring unter dem Präfix `spring.datasource` bekannt sind (vgl. link:https://docs.spring.io/spring-boot/appendix/application-properties/index.html#appendix.application-properties.data[Common Application Properties]).
 Die Konfiguration bietet damit die Flexibilität, Datenbanken verschiedener Anbieter zu nutzen, sofern diese von Spring Boot unterstützt sind.
 
 [WARNING]
 ====
-Die Nutzung der isy-persistence AutoConfiguration führt durch das Wrappen der DataSource in einer IsyDataSouce mit der `@Primary` und der `@DependsOnDatabaseInitialization` Annotation zu einer zyklischen Abhängigkeit zusammen mit der `SqlInitializationAutoConfiguration` von Spring Boot (betrifft `SqlDataSourceScriptDatabaseInitializer` Bean).
+Die Nutzung der `IsyPersistenceAutoConfiguration` führt durch das Verpacken der DataSource in eine `IsyDataSource` mit der `@Primary`- und `@DependsOnDatabaseInitialization`-Annotation zusammen mit der `SqlInitializationAutoConfiguration` von Spring Boot (betrifft `SqlDataSourceScriptDatabaseInitializer`-Bean) zu einer zyklischen Abhängigkeit.
 
 Dieses Problem kann durch Setzen der Property `spring.sql.init.mode=never` in der `application.properties` gelöst werden.
 ====
@@ -157,7 +157,7 @@ public class PersistenceConfig {
 ----
 
 Für die zweite Datenbankanbindung wird eine weitere Konfiguration angelegt <<listing-datasource2>>.
-Dafür können die von isy-persistence erweiterten DatabaseProperties verwendet werden, um durch Verpacken der DataSource in einer IsyDataSource die Schema-validierung zu nutzen.
+Dafür können die von isy-persistence erweiterten `DatabaseProperties` verwendet werden, um durch das Verpacken der DataSource in eine `IsyDataSource` die Schema-validierung zu nutzen.
 
 .Konfiguration der zweiten DataSource
 [id="listing-datasource2",reftext="{listing-caption} {counter:listings }"]

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-persistence/pages/nutzungsvorgaben/konfiguration.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-persistence/pages/nutzungsvorgaben/konfiguration.adoc
@@ -117,12 +117,10 @@ Einige Anwendungsfälle machen es notwendig, eine zweite Datenbank zu nutzen.
 Das ist beispielsweise notwendig, wenn Daten aus einem Altsystem über die Datenbank für andere Systeme bereitgestellt werden und diese Daten in eine IsyFact-Anwendung über einen Batch importiert werden sollen.
 Der Batch muss dann sowohl auf die Datenbank der IsyFact-Anwendung, als auch auf die Datenbank des Altsystems zugreifen.
 
-Die Anbindung einer zweiten Datenbank erfolgt analog zur Anbindung der primären Datenbank über Spring und die Nutzung über JPA.
+Die Anbindung einer zweiten Datenbank erfolgt analog zur Anbindung der primären Datenbank über Spring und die Nutzung von JPA.
 Dabei erfolgt der Zugriff auf die zweite Datenbank getrennt über einen weiteren Entity Manager und eine weitere Data Source.
 
-[[anbindung-einer-zweiten-datenbank]]
-=== Anbindung einer zweiten Datenbank
-Die Beans für die `EntityManagerFactory` und den `TransactionManager` müssen manuell konfiguriert werden <<listing-datasource1>>.
+Wird eine zweite Datenbank verwendet, müssen die Beans für `EntityManagerFactory` und den `TransactionManager` auch für die primäre Datenbank manuell konfiguriert werden <<listing-datasource1>>.
 Als `DataSource` wird hier die von `isy-persistence` automatisch konfigurierte `appDataSource` verwendet.
 
 .Konfiguration der ersten DataSource
@@ -159,6 +157,7 @@ public class PersistenceConfig {
 ----
 
 Für die zweite Datenbankanbindung wird eine weitere Konfiguration angelegt <<listing-datasource2>>.
+Dafür können die von isy-persistence erweiterten DatabaseProperties verwendet werden, um durch Verpacken der DataSource in einer IsyDataSource die Schema-validierung zu nutzen.
 
 .Konfiguration der zweiten DataSource
 [id="listing-datasource2",reftext="{listing-caption} {counter:listings }"]
@@ -168,22 +167,38 @@ Für die zweite Datenbankanbindung wird eine weitere Konfiguration angelegt <<li
 @EnableJpaRepositories(basePackages = "de.beispiel.zweidatasources.persistencesec", entityManagerFactoryRef = "entityManagerFactorySec", transactionManagerRef = "transactionManagerSec")
 public class Persistence2Config {
 
-    @Autowired
-    private Environment env;
+    @Bean("secondaryDatabaseProperties")
+    @ConfigurationProperties("isy.persistence.datasource2")
+    DatabaseProperties secondaryDatabaseProperties() {
+        return new DatabaseProperties();
+    }
 
-    @Bean
-    public DataSource dataSourceSec() {
-        JdbcDataSource dataSource = new JdbcDataSource();
-        dataSource.setUrl(env.getProperty("datasource.second.url"));
+    @Bean("secondaryDataSource")
+    @ConfigurationProperties(prefix = "isy.persistence.datasource2.config")
+    public DataSource secondaryDataSource(@Qualifier("secondaryDatabaseProperties") DataSourceProperties secondaryDatabaseProperties) {
+        return secondaryDatabaseProperties.initializeDataSourceBuilder().build();
+    }
 
-        return dataSource;
+    @Bean("secondaryAppDataSource")
+    @DependsOnDatabaseInitialization
+    public IsyDataSource secondaryAppDataSource(
+        @Qualifier("secondaryDataSource") DataSource secondaryDataSource,
+        @Qualifier("secondaryDatabaseProperties") DatabaseProperties secondaryDatabaseProperties
+    ) {
+        IsyDataSource isyDataSource = new IsyDataSource();
+        isyDataSource.setSchemaVersion(secondaryDatabaseProperties.getSchemaVersion());
+        isyDataSource.setInvalidSchemaVersionAction(secondaryDatabaseProperties.getSchemaInvalidVersionAction());
+        isyDataSource.setTargetDataSource(secondaryDataSource);
+        return isyDataSource;
     }
 
     @Bean
-    public LocalContainerEntityManagerFactoryBean entityManagerFactorySec(@Qualifier("dataSourceSec") DataSource dataSource) {
+    public LocalContainerEntityManagerFactoryBean entityManagerFactorySec(
+        @Qualifier("secondaryAppDataSource") DataSource secondaryAppDataSource
+    ) {
         LocalContainerEntityManagerFactoryBean em = new LocalContainerEntityManagerFactoryBean();
         em.setPackagesToScan("de.beispiel.zweidatasource.persistencesec");
-        em.setDataSource(dataSource);
+        em.setDataSource(secondaryAppDataSource);
         em.setJpaDialect(new HibernateJpaDialect());
 
         HibernateJpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
@@ -196,7 +211,7 @@ public class Persistence2Config {
     }
 
     @Bean
-    public PlatformTransactionManager transactionManagerSec(@Qualifier("entityManagerFactorySecc") EntityManagerFactory entityManagerFactory) {
+    public PlatformTransactionManager transactionManagerSec(@Qualifier("entityManagerFactorySec") EntityManagerFactory entityManagerFactory) {
         JpaTransactionManager transactionManager = new JpaTransactionManager();
         transactionManager.setEntityManagerFactory(entityManagerFactory);
         return transactionManager;

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-persistence/pages/nutzungsvorgaben/konfiguration.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-persistence/pages/nutzungsvorgaben/konfiguration.adoc
@@ -46,7 +46,18 @@ spring.jpa.properties.hibernate.transaction.coordinator_class=jdbc
 
 Als Datasource-Implementierung muss die Implementierung aus `de.bund.bva.isyfact.persistence.datasource.IsyDataSource` genutzt werden.
 Bei der Verwendung von `isy-persistence` wird automatisch eine Bean mit dem Namen `appDataSource` erzeugt.
-Diese prüft die Version des Datenbankschemas (siehe Abschnitt xref:nutzungsvorgaben/versionierung.adoc#pruefen-der-schemaversion[Prüfen der Schema-Version]) und dient als Wrapper für die wirkliche Datasource des Connections-Pools, dessen Konfiguration im nächsten Abschnitt erläutert wird.
+Diese prüft die Version des Datenbankschemas (siehe Abschnitt xref:nutzungsvorgaben/versionierung.adoc#pruefen-der-schemaversion[Prüfen der Schema-Version]) und dient als Wrapper für die eigentliche Spring `DataSource`.
+
+Die Autokonfiguration der IsyFact 3 Version von `isy-persistence` verwendet Spring Boot Meachnismen, um die `DataSource` zu konfigurieren.
+Unter dem Prefix `isy.persistence.datasource` können alle Properties konfiguriert werden, welche in Spring unter dem Prefix `spring.datasource` bekannt sind (vgl. link:https://docs.spring.io/spring-boot/appendix/application-properties/index.html#appendix.application-properties.data[Common Application Properties]).
+Die Konfiguration bietet damit die Flexibilität, Datenbanken verschiedener Anbieter zu nutzen, sofern diese von Spring Boot unterstützt sind.
+
+[WARNING]
+====
+Die Nutzung der isy-persistence AutoConfiguration führt durch das Wrappen der DataSource in einer IsyDataSouce mit der `@Primary` und der `@DependsOnDatabaseInitialization` Annotation zu einer zyklischen Abhängigkeit zusammen mit der `SqlInitializationAutoConfiguration` von Spring Boot (betrifft `SqlDataSourceScriptDatabaseInitializer` Bean).
+
+Dieses Problem kann durch Setzen der Property `spring.sql.init.mode=never` in der `application.properties` gelöst werden.
+====
 
 [[standardmaessig-lazy-loading-verwenden]]
 === Standardmäßig Lazy Loading verwenden


### PR DESCRIPTION
* docs(persistence): IFS-4010 detailed configuration of if3 persistence
* docs(persistence): IFS-4010 include persistence changes in migration guide
* test(persistence): IFS-4010 add AutoConfiguration Tests

    * test valid AutoConfiguration
    * expect circular reference

* docs(persistence): IFS-4010 update docs for secondary DataSource