### PR TITLE
chore: IFS-4212 replace @ManualTask with @OnceTask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
     * Funktionalität zur erneuten Authentifizierung wird von `BatchrahmenImpl` aufgerufen
 - `IFS-3928`: [isy-bedienkonzept] Migration der neusten Bedienkonzeptversion ins Repository isy-bedienkonzept
 ## BUG FIXES
+- `IFS-4212`: Dokumentation von `@OnceTask` korrigiert (`@ManualTask` existiert nicht)
 ## BREAKING CHANGES
 - `ISY-1122`: Bausteine `isy-sicherheit`, `isy-aufrufkontext`, `isy-serviceapi-core` und `isy-konfiguration` entfernt
 - `ISY-889`: Spring Boot Versionsanhebung auf 3.2.x

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-task/pages/nutzungsvorgaben.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-task/pages/nutzungsvorgaben.adoc
@@ -52,9 +52,9 @@ Das Starten und Stoppen eines Tasks wird durch Einsatz der Annotationen vollstä
 [[manuelles-starten-stoppen]]
 === Manuelles Starten und Stoppen von Tasks
 
-Es ist ebenfalls möglich, Tasks händisch zu starten und/oder zu stoppen. Zu diesem Zweck wurde `isy-task` um die Annotation `ManualTask` erweitert. Darüber hinaus kommt der `TaskScheduler` aus dem Spring-Framework zum Einsatz.
+Es ist ebenfalls möglich, Tasks händisch zu starten und/oder zu stoppen. Zu diesem Zweck wurde `isy-task` um die Annotation `OnceTask` erweitert. Darüber hinaus kommt der `TaskScheduler` aus dem Spring-Framework zum Einsatz.
 
-Eine Klasse, die einen Task bzw. eine Funktion beinhaltet, die manuell gestartet und gestoppt werden soll, muss zunächst mit @Component annotiert werden und das Runnable-Interface implementieren, damit die mit `@ManualTask` annotierte Methode von `isy-task` verarbeitet werden kann.
+Eine Klasse, die einen Task bzw. eine Funktion beinhaltet, die manuell gestartet und gestoppt werden soll, muss zunächst mit @Component annotiert werden und das Runnable-Interface implementieren, damit die mit `@OnceTask` annotierte Methode von `isy-task` verarbeitet werden kann.
 
 [source, java]
 ----
@@ -66,7 +66,7 @@ public class ProgrammaticallyScheduledTask implements Runnable {
     private static final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss");
 
     @Override
-    @ManualTask
+    @OnceTask
     public void run() {
         for (int i = 0; i < 3; i++) {
             try {
@@ -121,7 +121,7 @@ public class TestTaskScheduledProgrammatically {
 }
 ----
 
-Erweiterte Funktionalität: Es muss nicht zwangsläufig das Runnable-Interface implementiert werden, alternativ kann eine beliebige Methode mit @ManualTask annotiert werden. Diese muss anschließend per Lambda dem Scheduler übergeben werden:
+Erweiterte Funktionalität: Es muss nicht zwangsläufig das Runnable-Interface implementiert werden, alternativ kann eine beliebige Methode mit @OnceTask annotiert werden. Diese muss anschließend per Lambda dem Scheduler übergeben werden:
 
 [source, java]
 ----
@@ -136,7 +136,7 @@ public class TestTaskScheduledProgrammatically {
     private TaskScheduler taskScheduler;
 
     @Autowired
-    // has an @ManualTask-annotated execute()-Method
+    // has an @OnceTask-annotated execute()-Method
     private AlternativeTask task;
 
     @Test


### PR DESCRIPTION
### **User description**
- @ManualTask doesn't exist


___

### **PR Type**
documentation


___

### **Description**
- Replaced all instances of `@ManualTask` with `@OnceTask` in the documentation to correct the usage and description.
- Updated the changelog to include a note about the correction in the documentation for `@OnceTask`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog for `@OnceTask` documentation correction</code></dd></summary>
<hr>

CHANGELOG.md

<li>Added a bug fix entry for <code>IFS-4212</code> to correct documentation regarding <br><code>@OnceTask</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/IsyFact/isyfact-standards/pull/572/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>nutzungsvorgaben.adoc</strong><dd><code>Correct `@OnceTask` usage in task documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

isyfact-standards-doc/src/docs/antora/modules/isy-task/pages/nutzungsvorgaben.adoc

<li>Replaced <code>@ManualTask</code> with <code>@OnceTask</code> in multiple instances.<br> <li> Updated descriptions and code examples to reflect the change to <br><code>@OnceTask</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/IsyFact/isyfact-standards/pull/572/files#diff-dc393e40cc9ef76aa02b168abb80edcacb968512b36e97cf7697e55d4da80606">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information