### PR TITLE
[Sprint 113] IFS-4229 use correct version property for mapstruct

### DIFF
--- a/isyfact-products-bom/pom.xml
+++ b/isyfact-products-bom/pom.xml
@@ -188,12 +188,12 @@
             <dependency>
                 <groupId>org.mapstruct</groupId>
                 <artifactId>mapstruct</artifactId>
-                <version>${org.mapstruct.version}</version>
+                <version>${mapstruct.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.mapstruct</groupId>
                 <artifactId>mapstruct-processor</artifactId>
-                <version>${org.mapstruct.version}</version>
+                <version>${mapstruct.version}</version>
             </dependency>
 
             <!-- Code generation: pojobuilder -->


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fixed the version property for MapStruct dependencies in the `pom.xml` file by replacing `${org.mapstruct.version}` with `${mapstruct.version}`.
- Ensures the correct version of MapStruct is used in the build process.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pom.xml</strong><dd><code>Correct version property for MapStruct dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

isyfact-products-bom/pom.xml

<li>Corrected the version property for MapStruct dependencies.<br> <li> Replaced <code>${org.mapstruct.version}</code> with <code>${mapstruct.version}</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/IsyFact/isyfact-standards/pull/577/files#diff-25407368f6b6988d2bbc6741fede19671453fd72455ee80c095d6f494cfc7664">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information