### PR TITLE
Hotfix: Skipping Maven Build when updating docs

### DIFF
--- a/.github/workflows/maven_build.yml
+++ b/.github/workflows/maven_build.yml
@@ -1,17 +1,18 @@
-name: Check Maven
+# Maven Build: Compile, Test, SonarCloudScan
+name: Maven Build
 on:
   pull_request:
     branches:
       - master
       - 'release/**'
     paths-ignore:
-      - 'isyfact-standards-doc'
+      - 'isyfact-standards-doc/**'
   push:
     branches:
       - master
       - 'release/**'
     paths-ignore:
-      - 'isyfact-standards-doc'
+      - 'isyfact-standards-doc/**'
 
 jobs:
   Version:


### PR DESCRIPTION
### **PR Type**
configuration changes, enhancement


___

### **Description**
- Updated the GitHub Actions workflow configuration for Maven builds to improve clarity and functionality.
- Changed the workflow name to 'Maven Build' and adjusted paths-ignore to skip all subdirectories under 'isyfact-standards-doc'.
- Renamed the Maven job to 'MavenBuild' for better clarity.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>maven_build.yml</strong><dd><code>Update Maven build workflow configuration and naming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/maven_build.yml

<li>Updated workflow name from 'Check Maven' to 'Maven Build'.<br> <li> Modified paths-ignore to include all subdirectories under <br>'isyfact-standards-doc'.<br> <li> Renamed job 'Maven' to 'MavenBuild'.<br> <li> Added a more descriptive name for the Maven build process.


</details>


  </td>
  <td><a href="https://github.com/IsyFact/isyfact-standards/pull/584/files#diff-5e9df5c7ba9a0e12d454053f62cec530d95c52e2dc4a4f1e6755b6499686d764">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information