### PR TITLE
[Sprint 114] IFS-4006 add admonition regarding changes to the CSRF filter

### DIFF
--- a/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/inhalt.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/inhalt.adoc
@@ -376,6 +376,13 @@ public class OAuth2ServerSecurityConfig {
 }
 ----
 
+[INFO]
+====
+Bei der Verwendung von `isy-sicherheit` wurde der CSRF-Filter von Spring Security in vielen Fällen standarmäßig deaktiviert.
+Damit die von der Anwendung bereitgestellten Schnittstellen weiterhin ohne Probleme erreicht werden können, muss dieser mglw. durch entsprechende Konfiguration der `SecurityFilterChain` wieder deaktiviert werden: `http.csrf().disable()`.
+Dies soll nur falls absolut notwendig durchgeführt werden, um die Angriffsfläche der Anwendung nicht zu vergrößern.
+====
+
 [[konfigurationsparameterservice]]
 === Konfigurationsparameter
 


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Added a detailed admonition in the documentation about the default deactivation of the CSRF filter in Spring Security when using `isy-sicherheit`.
- Provided instructions on how to disable the CSRF filter through `SecurityFilterChain` configuration if necessary.
- Highlighted the importance of only disabling the CSRF filter when absolutely necessary to avoid increasing the application's attack surface.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>inhalt.adoc</strong><dd><code>Add admonition about CSRF filter configuration in documentation</code></dd></summary>
<hr>

isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/inhalt.adoc

<li>Added an admonition regarding the CSRF filter in Spring Security.<br> <li> Provided guidance on disabling the CSRF filter if necessary.<br> <li> Emphasized the security implications of disabling the CSRF filter.<br>


</details>


  </td>
  <td><a href="https://github.com/IsyFact/isyfact-standards/pull/596/files#diff-aedaf1b4a803dd5aa46ad0c7159d0a3ba7d227017fbbc6591917391872463bb7">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information