### PR TITLE
fix: ifs-0000: commented ORT since it's not working currently

### DIFF
--- a/.github/workflows/maven_dependency_scan.yml
+++ b/.github/workflows/maven_dependency_scan.yml
@@ -17,7 +17,7 @@ jobs:
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
-  ORT:
-    uses: IsyFact/isy-github-actions-templates/.github/workflows/oss_review_toolkit_template.yml@v1.5.0
-    secrets:
-      ANTORA_TRIGGER_TOKEN: ${{ secrets.ANTORA_TRIGGER_TOKEN }}
+#  ORT:
+#    uses: IsyFact/isy-github-actions-templates/.github/workflows/oss_review_toolkit_template.yml@v1.5.0
+#    secrets:
+#      ANTORA_TRIGGER_TOKEN: ${{ secrets.ANTORA_TRIGGER_TOKEN }}


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- Commented out the ORT job in the GitHub Actions workflow file as it is not currently working.
- Retained the existing SnykScan job configuration for dependency scanning.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>maven_dependency_scan.yml</strong><dd><code>Comment out ORT job in GitHub Actions workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/maven_dependency_scan.yml

<li>Commented out the ORT job configuration.<br> <li> Maintained the SnykScan job configuration.<br>


</details>


  </td>
  <td><a href="https://github.com/IsyFact/isyfact-standards/pull/612/files#diff-7ca9a6c40325715da9366953b85546c8eb60c7474bb8bda99903e66e79eb9447">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information