### PR TITLE
[Sprint-119] IFS-979 concurrency improvements DefaultServiceStatistik

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - `IFS-4236`: [isy-datetime], [isy-sonderzeichen] Beide Submodule wurden aus `isyfact-standards` entfernt und in eigenständige Repositories verschoben
     * Sie werden ab sofort entkoppelt von der Isyfact versioniert und weiterentwickelt
     * Sie werden aber weiterhin im Dependency-Management der `isyfact-standards-bom` angeboten.
+- `IFS-979`: [isy-ueberwachung] Verbesserung der Nebenläufigkeit von DefaultServiceStatistik.
 
 ## BUG FIXES
 - `IFS-4194`: Umstellung aller Verweise in der Referenzarchitektur aufs Glossar auf das aktuelle Format (`xref:glossary::terms-definitions.adoc`)

--- a/isy-ueberwachung/CHANGELOG.md
+++ b/isy-ueberwachung/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 4.0.0
 - `ISY-888`: Freigabe des `/Loadbalancer` Endpunkts auf `SecurityFilterChain` (`@Order(99)`) umgestellt
 - `ISY-601`: Standardabsicherung und Konfigurationsparameter werden per AutoConfiguration bereitgestellt.
+- `IFS-979`: Verbesserung der Nebenläufigkeit von DefaultServiceStatistik.
 
 # 3.0.0
 - `IFS-1702`: Refaktorierung ServiceStatistik

--- a/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/metrics/impl/DefaultServiceStatistik.java
+++ b/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/metrics/impl/DefaultServiceStatistik.java
@@ -25,8 +25,8 @@ import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.stream.Collectors;
 
 import org.aopalliance.intercept.MethodInterceptor;
@@ -72,7 +72,7 @@ public class DefaultServiceStatistik implements ServiceStatistik, MethodIntercep
     /**
      * Duration of the last search calls (in milliseconds).
      */
-    private final List<Duration> letzteSuchdauern = new LinkedList<>();
+    private final ConcurrentLinkedDeque<Duration> letzteSuchdauern = new ConcurrentLinkedDeque<>();
 
     /**
      * Flag for the minute in which values of the last minute were determined.
@@ -176,10 +176,10 @@ public class DefaultServiceStatistik implements ServiceStatistik, MethodIntercep
         }
 
         if (letzteSuchdauern.size() == ANZAHL_AUFRUFE_FUER_DURCHSCHNITT) {
-            letzteSuchdauern.remove(ANZAHL_AUFRUFE_FUER_DURCHSCHNITT - 1);
+            letzteSuchdauern.removeLast();
         }
 
-        letzteSuchdauern.add(0, dauer);
+        letzteSuchdauern.addFirst(dauer);
     }
 
     /**


### PR DESCRIPTION
* feat(ueberwachung): IFS-979 replace LinkedList with ConcurrentLinkedDequeue
* feat(ueberwachung): IFS-979 replace fields referenced in zaehleAufruf with Atomic types
    * also replace letzteMinute to minimize thread locking
* feat(ueberwachung): IFS-979 add synchronized blocks
    * necessary to assure correct concurrent behaviour
    * blocks are as small as possible with locks not locking the whole service but individual fields of the service
* chore(ueberwachung): IFS-979 update changelogs