### PR TITLE
IFRF-321  IF 3.1: isy-logging: MdcFilterAutoConfiguration ist keine AutoConfiguration

### DIFF
--- a/isy-aufrufkontext/src/main/resources/META-INF/spring.factories
+++ b/isy-aufrufkontext/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-de.bund.bva.isyfact.logging.autoconfigure.MdcFilterAutoConfiguration

--- a/isy-logging/src/main/resources/META-INF/spring.factories
+++ b/isy-logging/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,4 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 de.bund.bva.isyfact.logging.autoconfigure.IsyLoggingAutoConfiguration,\
-de.bund.bva.isyfact.logging.autoconfigure.IsyPerformanceLoggingAutoConfiguration
+de.bund.bva.isyfact.logging.autoconfigure.IsyPerformanceLoggingAutoConfiguration,\
+de.bund.bva.isyfact.logging.autoconfigure.MdcFilterAutoConfiguration


### PR DESCRIPTION
Mit der IF 3 wurde die MdcFilterAutoConfiguration von isy-aufrufkontext nach isy-logging verlagert. Leider wurde aber die META-INF/spring.factories nicht mit umgestellt.