### PR TITLE
[Sprint 123] IFS-4529 spring boot 343 update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,11 @@
 - `IFS-3736`: [isyfact-standards-doc] Abbildung von Anwendungen in IT-Systeme ("technischer Schnitt") beschrieben.
 - `IFS-3763`: [isyfact-standards-doc] Dokumentation der Änderungen zu IFS-2248 (Tokenerneuerung isy-batchrahmen)
 - `IFS-3750`: [isyfact-standards-doc] Baustein Konfiguration entfernt.
+- `IFS-4529`: Spring Boot Versionsanhebung auf 3.4.x:
+    * [isy-ueberwachung]: Signaturänderung von de.bund.bva.isyfact.ueberwachung.config.NachbarsystemRestTemplateConfigurer.CustomErrorHandler.handleError
+    * [isy-ueberwachung]: Folgende Property-Keys ändern sich:
+      - management.endpoints.enabled-by-default -> management.endpoints.access.default
+      - management.endpoint.<id>.enabled -> management.endpoint.<id>.access
 
 # 3.0.1
 - `ISY-701`: Google Guava Versionsanhebung auf 33.1.0

--- a/isy-batchrahmen/src/main/java/de/bund/bva/isyfact/batchrahmen/config/BatchSecurityConfiguration.java
+++ b/isy-batchrahmen/src/main/java/de/bund/bva/isyfact/batchrahmen/config/BatchSecurityConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.security.oauth2.client.ClientsConfiguredCondition;
 import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
-import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientPropertiesRegistrationAdapter;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientPropertiesMapper;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -46,8 +46,8 @@ public class BatchSecurityConfiguration {
     @Bean
     @ConditionalOnMissingBean(ClientRegistrationRepository.class)
     InMemoryClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties properties) {
-        List<ClientRegistration> registrations = new ArrayList<>(
-                OAuth2ClientPropertiesRegistrationAdapter.getClientRegistrations(properties).values());
+        var mapper = new OAuth2ClientPropertiesMapper(properties);
+        List<ClientRegistration> registrations = new ArrayList<>(mapper.asClientRegistrations().values());
         return new InMemoryClientRegistrationRepository(registrations);
     }
 

--- a/isy-persistence/src/test/java/de/bund/bva/isyfact/persistence/autoconfigure/IsyPersistenceAutoConfigurationTest.java
+++ b/isy-persistence/src/test/java/de/bund/bva/isyfact/persistence/autoconfigure/IsyPersistenceAutoConfigurationTest.java
@@ -71,8 +71,8 @@ class IsyPersistenceAutoConfigurationTest {
                 assertThat(context).hasFailed()
                     .getFailure()
                     .cause()
-                    .isInstanceOf(BeanCurrentlyInCreationException.class)
-                    .hasMessageContaining("Is there an unresolvable circular reference?");
+                        .hasRootCauseInstanceOf(BeanCurrentlyInCreationException.class)
+                        .hasMessageContaining("Is there an unresolvable circular reference");
             });
     }
 

--- a/isy-polling/src/test/java/de/bund/bva/isyfact/polling/config/IsyPollingPropertiesTest.java
+++ b/isy-polling/src/test/java/de/bund/bva/isyfact/polling/config/IsyPollingPropertiesTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.context.properties.bind.validation.BindValidationException;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
@@ -64,7 +65,7 @@ class IsyPollingPropertiesTest {
             assertThat(context).hasFailed()
                 .getFailure()
                 .cause()
-                .isInstanceOf(BeanCreationException.class)
+                    .hasRootCauseInstanceOf(BindValidationException.class)
         );
     }
 

--- a/isy-task/src/test/java/de/bund/bva/isyfact/task/TestTaskAuthentication.java
+++ b/isy-task/src/test/java/de/bund/bva/isyfact/task/TestTaskAuthentication.java
@@ -12,6 +12,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.test.context.ActiveProfiles;
 
 import de.bund.bva.isyfact.task.test.TestTaskRunAssertion;
@@ -94,6 +96,6 @@ class TestTaskAuthentication extends AbstractOidcProviderTest {
         SECONDS.sleep(5);
 
         TestTaskRunAssertion.assertTaskFailure(className, annotatedMethodName, registry,
-                AccessDeniedException.class.getSimpleName());
+                AuthorizationDeniedException.class.getSimpleName());
     }
 }

--- a/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/autoconfigure/IsyActuatorSecurityAutoConfiguration.java
+++ b/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/autoconfigure/IsyActuatorSecurityAutoConfiguration.java
@@ -19,6 +19,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 import de.bund.bva.isyfact.ueberwachung.config.ActuatorSecurityConfigurationProperties;
 /* tag::actuatorSecurity[] */
@@ -47,10 +48,14 @@ public class IsyActuatorSecurityAutoConfiguration {
     @Order(1)
     @ConditionalOnMissingBean(name = "actuatorSecurityFilterChain")
     public SecurityFilterChain actuatorSecurityFilterChain(HttpSecurity http) throws Exception {
-        http.authorizeHttpRequests(requests -> requests
-                .requestMatchers(EndpointRequest.toAnyEndpoint())
-                .hasRole(ENDPOINT_ROLE))
-            .httpBasic(withDefaults());
+        http
+                .securityMatcher(new AntPathRequestMatcher("**"))
+                .authorizeHttpRequests(
+                        requests -> requests
+                    .requestMatchers(EndpointRequest.toAnyEndpoint())
+                    .hasRole(ENDPOINT_ROLE)
+                )
+                .httpBasic(withDefaults());
         return http.build();
     }
 

--- a/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/config/LoadbalancerSecurityConfiguration.java
+++ b/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/config/LoadbalancerSecurityConfiguration.java
@@ -7,6 +7,7 @@ import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
 @EnableWebSecurity
@@ -31,10 +32,12 @@ public class LoadbalancerSecurityConfiguration {
     @Bean
     @Order(99)
     SecurityFilterChain loadbalancerSecurityFilterChain(HttpSecurity http) throws Exception {
-        http.authorizeHttpRequests(
-            auth -> auth
-                .requestMatchers(LOADBALANCER_SERVLET_PATH)
-                .permitAll()
+        http
+                .securityMatcher(new AntPathRequestMatcher("**"))
+                .authorizeHttpRequests(
+                        auth -> auth
+                                .requestMatchers(LOADBALANCER_SERVLET_PATH)
+                                .permitAll()
         );
         return http.build();
     }

--- a/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/config/NachbarsystemRestTemplateConfigurer.java
+++ b/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/config/NachbarsystemRestTemplateConfigurer.java
@@ -1,9 +1,11 @@
 package de.bund.bva.isyfact.ueberwachung.config;
 
 import java.io.IOException;
+import java.net.URI;
 import java.time.Duration;
 
 import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.client.ClientHttpResponse;
@@ -23,9 +25,9 @@ public final class NachbarsystemRestTemplateConfigurer {
         Duration timeout =
             properties.getNachbarsystemCheck().getTimeout();
         return builder
-            .setConnectTimeout(timeout)
-            .setReadTimeout(timeout)
-            .errorHandler(new CustomErrorHandler());
+                .connectTimeout(timeout)
+                .readTimeout(timeout)
+                .errorHandler(new CustomErrorHandler());
     }
 
     /**
@@ -36,12 +38,12 @@ public final class NachbarsystemRestTemplateConfigurer {
     public static class CustomErrorHandler extends DefaultResponseErrorHandler {
 
         @Override
-        public void handleError(@NonNull ClientHttpResponse response, @NonNull HttpStatusCode statusCode)
+        public void handleError(@NonNull ClientHttpResponse response, @NonNull HttpStatusCode statusCode, URI uri, HttpMethod method)
             throws IOException {
 
             //skip Default Error Handling for SERVICE_UNAVAILABLE
             if (statusCode.value() != HttpStatus.SERVICE_UNAVAILABLE.value()) {
-                super.handleError(response, statusCode);
+                super.handleError(response, statusCode, uri, method);
             }
         }
     }

--- a/isy-ueberwachung/src/main/resources/config/health.properties
+++ b/isy-ueberwachung/src/main/resources/config/health.properties
@@ -1,8 +1,8 @@
-management.endpoints.enabled-by-default=false
+management.endpoints.access.default=none
 management.endpoint.health.show-details=never
-management.endpoint.health.enabled=true
-management.endpoint.metrics.enabled=true
-management.endpoint.info.enabled=true
+management.endpoint.health.access=unrestricted
+management.endpoint.metrics.access=unrestricted
+management.endpoint.info.access=unrestricted
 management.endpoints.jmx.exposure.exclude=*
 management.endpoints.web.exposure.include=health,metrics,info
 

--- a/isyfact-products-bom/pom.xml
+++ b/isyfact-products-bom/pom.xml
@@ -15,7 +15,7 @@
     <description>Definiert die Versionen aller 3rd-Party Abhängigkeiten des Core Technology Stack der IsyFact.</description>
 
     <properties>
-        <spring.boot.version>3.2.5</spring.boot.version>
+        <spring.boot.version>3.4.3</spring.boot.version>
         <resilience4j.version>1.7.1</resilience4j.version>
         <apache.poi.version>4.1.2</apache.poi.version>
         <greenmail.version>1.6.15</greenmail.version>


### PR DESCRIPTION
* build: IFS-4529 update spring boot to 3.4.3

* feat: IFS-4529 replace removed OAuth2ClientPropertiesRegistrationAdapter with OAuth2ClientPropertiesMapper

* test: IFS-4529 adapt test cases to changed spring behavior

* refactor: IFS-4529 update ErrorHandler overrides, remove deprecated method usage

    BREAKING CHANGE: de.bund.bva.isyfact.ueberwachung.config.NachbarsystemRestTemplateConfigurer.CustomErrorHandler.handleError signature changed

* refactor: IFS-4529 add necessary security matchers

* chore: IFS-4529 update deprecated config keys

* chore: IFS-4529 update changelog

