### PR TITLE
[Sprint 125] IFS-4591: isy-security: Authentifizierung von Clients und Systemen ohne Issuer-URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `IFS-4570`: [isyfact-standards-doc] Alte Einträge aus Negativliste entfernt
 - `IFS-4549`: [isyfact-standards-doc] Verwaltung von Versionen zentralisiert
 - `IFS-4584`: [isyfact-standards-doc] Entfernung von `isy-asciidoctorj-extensions`
+- `IFS-4591`: [isy-security] Hinzufügen von Authentifizierungsmethoden zur Authentifizierung von Clients und Systemen ohne Issuer-URI.
 
 ## BUG FIXES
 - `IFS-4526`: [isy-task] Logeintrag IsyTaskAspect korrigiert

--- a/isy-security/CHANGELOG.md
+++ b/isy-security/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.1.0
+
+- `IFS-4591`: Hinzufügen von Authentifizierungsmethoden zur Authentifizierung von Clients und Systemen ohne Issuer-URI.
+
 # 4.0.0
 
 - `ISY-305`: Implementierung von IsySecurityTokenUtil zum Auslesen von Attributen aus dem Bearer Token

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/config/AdditionalCredentials.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/config/AdditionalCredentials.java
@@ -34,7 +34,7 @@ public final class AdditionalCredentials {
      * @param password the password of the resource owner
      * @return a new AdditionalCredentials instance
      */
-    public static AdditionalCredentials withUsernamePassword(String username, String password) {
+    public static AdditionalCredentials createWithUsernamePassword(String username, String password) {
         Assert.notNull(username, "username cannot be null");
         Assert.notNull(password, "password cannot be null");
         return new AdditionalCredentials(username, password, null);
@@ -48,7 +48,7 @@ public final class AdditionalCredentials {
      * @param bhknz the BHKNZ to be sent as part of the authentication request
      * @return a new AdditionalCredentials instance
      */
-    public static AdditionalCredentials withUsernamePasswordBhknz(String username, String password, String bhknz) {
+    public static AdditionalCredentials createWithUsernamePasswordBhknz(String username, String password, String bhknz) {
         Assert.notNull(username, "username cannot be null");
         Assert.notNull(password, "password cannot be null");
         Assert.notNull(bhknz, "bhknz cannot be null");
@@ -61,7 +61,7 @@ public final class AdditionalCredentials {
      * @param bhknz the BHKNZ to be sent as part of the authentication request
      * @return a new AdditionalCredentials instance
      */
-    public static AdditionalCredentials withBhknz(String bhknz) {
+    public static AdditionalCredentials createWithBhknz(String bhknz) {
         Assert.notNull(bhknz, "bhknz cannot be null");
         return new AdditionalCredentials(null, null, bhknz);
     }

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/config/AdditionalCredentials.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/config/AdditionalCredentials.java
@@ -1,0 +1,101 @@
+package de.bund.bva.isyfact.security.config;
+
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Builder class for additional authentication data that can be used for authentication with an OAuth 2.0 client.
+ * Can create combinations of bhknz, username + password and username + password + bhknz.
+ */
+public final class AdditionalCredentials {
+
+    /** The resource owner's username. */
+    @Nullable
+    private final String username;
+
+    /** The resource owner's password. */
+    @Nullable
+    private final String password;
+
+    /** The BHKNZ to send as part of the authentication request. */
+    @Nullable
+    private final String bhknz;
+
+    private AdditionalCredentials(@Nullable String username, @Nullable String password, @Nullable String bhknz) {
+        this.username = username;
+        this.password = password;
+        this.bhknz = bhknz;
+    }
+
+    /**
+     * Creates a builder-object for AdditionalCredentials with username and password.
+     *
+     * @param username the username of the resource owner
+     * @param password the password of the resource owner
+     * @return a new AdditionalCredentials instance
+     */
+    public static AdditionalCredentials withUsernamePassword(String username, String password) {
+        Assert.notNull(username, "username cannot be null");
+        Assert.notNull(password, "password cannot be null");
+        return new AdditionalCredentials(username, password, null);
+    }
+
+    /**
+     * Creates a builder-object for AdditionalCredentials with username, password and BHKNZ.
+     *
+     * @param username the username of the resource owner
+     * @param password the password of the resource owner
+     * @param bhknz the BHKNZ to be sent as part of the authentication request
+     * @return a new AdditionalCredentials instance
+     */
+    public static AdditionalCredentials withUsernamePasswordBhknz(String username, String password, String bhknz) {
+        Assert.notNull(username, "username cannot be null");
+        Assert.notNull(password, "password cannot be null");
+        Assert.notNull(bhknz, "bhknz cannot be null");
+        return new AdditionalCredentials(username, password, bhknz);
+    }
+
+    /**
+     * Creates a builder-object for AdditionalCredentials only with BHKNZ.
+     *
+     * @param bhknz the BHKNZ to be sent as part of the authentication request
+     * @return a new AdditionalCredentials instance
+     */
+    public static AdditionalCredentials withBhknz(String bhknz) {
+        Assert.notNull(bhknz, "bhknz cannot be null");
+        return new AdditionalCredentials(null, null, bhknz);
+    }
+
+    @Nullable
+    public String getUsername() {
+        return username;
+    }
+
+    @Nullable
+    public String getPassword() {
+        return password;
+    }
+
+    @Nullable
+    public String getBhknz() {
+        return bhknz;
+    }
+
+    /**
+     * Checks whether the username and password are set.
+     *
+     * @return true if username and password are set, otherwise false
+     */
+    public boolean hasUsernamePassword() {
+        return username != null && password != null;
+    }
+
+    /**
+     * Checks whether the BHKNZ is set.
+     *
+     * @return true if BHKNZ is set, otherwise false
+     */
+    public boolean hasBhknz() {
+        return bhknz != null;
+    }
+}

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/client/Authentifizierungsmanager.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/client/Authentifizierungsmanager.java
@@ -82,6 +82,7 @@ public interface Authentifizierungsmanager {
      *         if authentication fails
      * @see #authentifiziereClient(String, String, String, String)
      */
+    @Deprecated
     void authentifiziereClient(String issuerLocation, String clientId, String clientSecret) throws AuthenticationException;
 
     /**
@@ -104,6 +105,7 @@ public interface Authentifizierungsmanager {
      *         if authentication fails
      * @see #authentifiziereClient(String, String, String)
      */
+    @Deprecated
     void authentifiziereClient(String issuerLocation, String clientId, String clientSecret, @Nullable String bhknz)
             throws AuthenticationException;
 
@@ -129,6 +131,7 @@ public interface Authentifizierungsmanager {
      *         if authentication fails
      * @see #authentifiziereSystem(String, String, String, String, String, String)
      */
+    @Deprecated
     void authentifiziereSystem(String issuerLocation, String clientId, String clientSecret, String username, String password)
             throws AuthenticationException;
 
@@ -156,6 +159,7 @@ public interface Authentifizierungsmanager {
      *         if authentication fails
      * @see #authentifiziereSystem(String, String, String, String, String)
      */
+    @Deprecated
     void authentifiziereSystem(String issuerLocation, String clientId, String clientSecret, String username, String password, @Nullable String bhknz)
             throws AuthenticationException;
 

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/client/Authentifizierungsmanager.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/client/Authentifizierungsmanager.java
@@ -5,9 +5,10 @@ import java.time.Duration;
 import org.springframework.lang.Nullable;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.server.resource.authentication.AbstractOAuth2TokenAuthenticationToken;
 
+import de.bund.bva.isyfact.security.config.AdditionalCredentials;
 import de.bund.bva.isyfact.security.config.IsyOAuth2ClientConfigurationProperties;
 
 /**
@@ -40,6 +41,28 @@ public interface Authentifizierungsmanager {
     void authentifiziere(String oauth2ClientRegistrationId) throws AuthenticationException;
 
     /**
+     * Attempts to authorize the client for the given {@code oauth2ClientRegistrationId} via its configured OAuth 2.0 Flow
+     * using the provided additional credentials.
+     * After successful authentication the authenticated principal in the {@link SecurityContext} will be updated.
+     * <p>
+     * The chosen OAuth 2.0 Flow will depend on the authorization grant type configured in the application properties.
+     * The currently supported flows are:
+     * <ul>
+     *     <li>Client Credentials (grant type: client_credentials)</li>
+     *     <li>Resource Owner Password Credentials (grant type: password)</li>
+     * </ul>
+     *
+     * @param oauth2ClientRegistrationId
+     *         registration ID of the OAuth 2.0 Client to authorize
+     * @param credentials
+     *         additional credentials to use for authentication, such as username, password, and/or bhknz
+     * @throws AuthenticationException
+     *         if authentication fails
+     * @see AdditionalCredentials
+     */
+    void authentifiziere(String oauth2ClientRegistrationId, AdditionalCredentials credentials) throws AuthenticationException;
+
+    /**
      * Performs authentication for the given {@code oauth2ClientRegistrationId} as described in
      * {@link Authentifizierungsmanager#authentifiziere(String)} if the SecurityContext does not contain
      * an Authentication of type {@link AbstractOAuth2TokenAuthenticationToken} or the token received from the
@@ -63,6 +86,49 @@ public interface Authentifizierungsmanager {
      * @see Authentifizierungsmanager#authentifiziere(String)
      */
     void authentifiziere(String oauth2ClientRegistrationId, Duration expirationTimeOffset) throws AuthenticationException;
+
+    /**
+     * Attempts to authorize a client using the provided {@link ClientRegistration} object via the OAuth 2.0 Client Credentials Flow.
+     * After successful authentication the authenticated principal in the {@link SecurityContext} will be updated.
+     * <p>
+     * This method allows authentication with a manually created {@link ClientRegistration} when no registration ID
+     * is configured.
+     * <p>
+     * This method only supports the Client Credentials flow (grant type: client_credentials). For authentication using
+     * the Resource Owner Password Credentials flow, use
+     * {@link #authentifiziere(ClientRegistration, AdditionalCredentials) authentifiziere with AdditionalCredentials} instead.
+     *
+     * @param clientRegistration
+     *         the client registration containing all necessary information for authentication
+     * @throws AuthenticationException
+     *         if authentication fails
+     */
+    void authentifiziere(ClientRegistration clientRegistration) throws AuthenticationException;
+
+    /**
+     * Attempts to authorize a client using the provided {@link ClientRegistration} object and additional credentials
+     * via the configured OAuth 2.0 Flow. After successful authentication the authenticated principal in the
+     * {@link SecurityContext} will be updated.
+     * <p>
+     * This method allows authentication with a manually created {@link ClientRegistration} when no registration ID
+     * is configured.
+     * <p>
+     * The chosen OAuth 2.0 Flow will depend on the authorization grant type in the provided client registration.
+     * The currently supported flows are:
+     * <ul>
+     *     <li>Client Credentials (grant type: client_credentials)</li>
+     *     <li>Resource Owner Password Credentials (grant type: password)</li>
+     * </ul>
+     *
+     * @param clientRegistration
+     *         the client registration containing all necessary information for authentication
+     * @param credentials
+     *         additional credentials to use for authentication, such as username, password, and/or bhknz
+     * @throws AuthenticationException
+     *         if authentication fails
+     * @see AdditionalCredentials
+     */
+    void authentifiziere(ClientRegistration clientRegistration, AdditionalCredentials credentials) throws AuthenticationException;
 
     /**
      * Attempts to create and authorize a client with the given credentials via the OAuth 2.0 Client Credentials Flow.

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/client/IsyOAuth2Authentifizierungsmanager.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/client/IsyOAuth2Authentifizierungsmanager.java
@@ -77,11 +77,13 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
     }
 
     @Override
+    @Deprecated
     public void authentifiziereClient(String issuerLocation, String clientId, String clientSecret) throws AuthenticationException {
         authentifiziereClient(issuerLocation, clientId, clientSecret, null);
     }
 
     @Override
+    @Deprecated
     public void authentifiziereClient(String issuerLocation, String clientId, String clientSecret, @Nullable String bhknz) throws AuthenticationException {
         Assert.notNull(issuerLocation, "issuerLocation cannot be null");
         Assert.notNull(clientId, "clientId cannot be null");
@@ -98,11 +100,13 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
     }
 
     @Override
+    @Deprecated
     public void authentifiziereSystem(String issuerLocation, String clientId, String clientSecret, String username, String password) throws AuthenticationException {
         authentifiziereSystem(issuerLocation, clientId, clientSecret, username, password, null);
     }
 
     @Override
+    @Deprecated
     public void authentifiziereSystem(String issuerLocation, String clientId, String clientSecret, String username, String password, @Nullable String bhknz)
             throws AuthenticationException {
         Assert.notNull(issuerLocation, "issuerLocation cannot be null");

--- a/isy-security/src/test/java/de/bund/bva/isyfact/security/config/AdditionalCredentialsTest.java
+++ b/isy-security/src/test/java/de/bund/bva/isyfact/security/config/AdditionalCredentialsTest.java
@@ -1,0 +1,105 @@
+package de.bund.bva.isyfact.security.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class AdditionalCredentialsTest {
+
+    private static final String TEST_USERNAME = "testuser";
+    private static final String TEST_PASSWORD = "testpassword";
+    private static final String TEST_BHKNZ = "900600";
+
+    @Test
+    public void testWithUsernamePassword() {
+        AdditionalCredentials credentials = AdditionalCredentials.withUsernamePassword(TEST_USERNAME, TEST_PASSWORD);
+
+        assertEquals(TEST_USERNAME, credentials.getUsername());
+        assertEquals(TEST_PASSWORD, credentials.getPassword());
+
+        assertNull(credentials.getBhknz());
+
+        assertTrue(credentials.hasUsernamePassword());
+        assertFalse(credentials.hasBhknz());
+    }
+
+    @Test
+    public void testWithUsernamePasswordBhknz() {
+        AdditionalCredentials credentials = AdditionalCredentials.withUsernamePasswordBhknz(
+                TEST_USERNAME, TEST_PASSWORD, TEST_BHKNZ);
+
+        assertEquals(TEST_USERNAME, credentials.getUsername());
+        assertEquals(TEST_PASSWORD, credentials.getPassword());
+        assertEquals(TEST_BHKNZ, credentials.getBhknz());
+
+        assertTrue(credentials.hasUsernamePassword());
+        assertTrue(credentials.hasBhknz());
+    }
+
+    @Test
+    public void testWithBhknz() {
+        AdditionalCredentials credentials = AdditionalCredentials.withBhknz(TEST_BHKNZ);
+
+        assertEquals(TEST_BHKNZ, credentials.getBhknz());
+
+        assertNull(credentials.getUsername());
+        assertNull(credentials.getPassword());
+
+        assertFalse(credentials.hasUsernamePassword());
+        assertTrue(credentials.hasBhknz());
+    }
+
+    @Test
+    public void testWithUsernamePasswordNullUsername() {
+        assertThrows(IllegalArgumentException.class,
+                () -> AdditionalCredentials.withUsernamePassword(null, TEST_PASSWORD));
+    }
+
+    @Test
+    public void testWithUsernamePasswordNullPassword() {
+        assertThrows(IllegalArgumentException.class,
+                () -> AdditionalCredentials.withUsernamePassword(TEST_USERNAME, null));
+    }
+
+    @Test
+    public void testWithUsernamePasswordBhknzNullUsername() {
+        assertThrows(IllegalArgumentException.class,
+                () -> AdditionalCredentials.withUsernamePasswordBhknz(null, TEST_PASSWORD, TEST_BHKNZ));
+    }
+
+    @Test
+    public void testWithUsernamePasswordBhknzNullPassword() {
+        assertThrows(IllegalArgumentException.class,
+                () -> AdditionalCredentials.withUsernamePasswordBhknz(TEST_USERNAME, null, TEST_BHKNZ));
+    }
+
+    @Test
+    public void testWithUsernamePasswordBhknzNullBhknz() {
+        assertThrows(IllegalArgumentException.class,
+                () -> AdditionalCredentials.withUsernamePasswordBhknz(TEST_USERNAME, TEST_PASSWORD, null));
+    }
+
+    @Test
+    public void testWithBhknzNullBhknz() {
+        assertThrows(IllegalArgumentException.class,
+                () -> AdditionalCredentials.withBhknz(null));
+    }
+
+    @Test
+    public void testHasUsernamePasswordBothNull() {
+        AdditionalCredentials credentials = AdditionalCredentials.withBhknz(TEST_BHKNZ);
+
+        assertFalse(credentials.hasUsernamePassword());
+    }
+
+    @Test
+    public void testHasBhknzNullBhknz() {
+        AdditionalCredentials credentials = AdditionalCredentials.withUsernamePassword(TEST_USERNAME, TEST_PASSWORD);
+
+        assertFalse(credentials.hasBhknz());
+    }
+}

--- a/isy-security/src/test/java/de/bund/bva/isyfact/security/config/AdditionalCredentialsTest.java
+++ b/isy-security/src/test/java/de/bund/bva/isyfact/security/config/AdditionalCredentialsTest.java
@@ -16,7 +16,7 @@ public class AdditionalCredentialsTest {
 
     @Test
     public void testWithUsernamePassword() {
-        AdditionalCredentials credentials = AdditionalCredentials.withUsernamePassword(TEST_USERNAME, TEST_PASSWORD);
+        AdditionalCredentials credentials = AdditionalCredentials.createWithUsernamePassword(TEST_USERNAME, TEST_PASSWORD);
 
         assertEquals(TEST_USERNAME, credentials.getUsername());
         assertEquals(TEST_PASSWORD, credentials.getPassword());
@@ -29,7 +29,7 @@ public class AdditionalCredentialsTest {
 
     @Test
     public void testWithUsernamePasswordBhknz() {
-        AdditionalCredentials credentials = AdditionalCredentials.withUsernamePasswordBhknz(
+        AdditionalCredentials credentials = AdditionalCredentials.createWithUsernamePasswordBhknz(
                 TEST_USERNAME, TEST_PASSWORD, TEST_BHKNZ);
 
         assertEquals(TEST_USERNAME, credentials.getUsername());
@@ -42,7 +42,7 @@ public class AdditionalCredentialsTest {
 
     @Test
     public void testWithBhknz() {
-        AdditionalCredentials credentials = AdditionalCredentials.withBhknz(TEST_BHKNZ);
+        AdditionalCredentials credentials = AdditionalCredentials.createWithBhknz(TEST_BHKNZ);
 
         assertEquals(TEST_BHKNZ, credentials.getBhknz());
 
@@ -56,49 +56,49 @@ public class AdditionalCredentialsTest {
     @Test
     public void testWithUsernamePasswordNullUsername() {
         assertThrows(IllegalArgumentException.class,
-                () -> AdditionalCredentials.withUsernamePassword(null, TEST_PASSWORD));
+                () -> AdditionalCredentials.createWithUsernamePassword(null, TEST_PASSWORD));
     }
 
     @Test
     public void testWithUsernamePasswordNullPassword() {
         assertThrows(IllegalArgumentException.class,
-                () -> AdditionalCredentials.withUsernamePassword(TEST_USERNAME, null));
+                () -> AdditionalCredentials.createWithUsernamePassword(TEST_USERNAME, null));
     }
 
     @Test
     public void testWithUsernamePasswordBhknzNullUsername() {
         assertThrows(IllegalArgumentException.class,
-                () -> AdditionalCredentials.withUsernamePasswordBhknz(null, TEST_PASSWORD, TEST_BHKNZ));
+                () -> AdditionalCredentials.createWithUsernamePasswordBhknz(null, TEST_PASSWORD, TEST_BHKNZ));
     }
 
     @Test
     public void testWithUsernamePasswordBhknzNullPassword() {
         assertThrows(IllegalArgumentException.class,
-                () -> AdditionalCredentials.withUsernamePasswordBhknz(TEST_USERNAME, null, TEST_BHKNZ));
+                () -> AdditionalCredentials.createWithUsernamePasswordBhknz(TEST_USERNAME, null, TEST_BHKNZ));
     }
 
     @Test
     public void testWithUsernamePasswordBhknzNullBhknz() {
         assertThrows(IllegalArgumentException.class,
-                () -> AdditionalCredentials.withUsernamePasswordBhknz(TEST_USERNAME, TEST_PASSWORD, null));
+                () -> AdditionalCredentials.createWithUsernamePasswordBhknz(TEST_USERNAME, TEST_PASSWORD, null));
     }
 
     @Test
     public void testWithBhknzNullBhknz() {
         assertThrows(IllegalArgumentException.class,
-                () -> AdditionalCredentials.withBhknz(null));
+                () -> AdditionalCredentials.createWithBhknz(null));
     }
 
     @Test
     public void testHasUsernamePasswordBothNull() {
-        AdditionalCredentials credentials = AdditionalCredentials.withBhknz(TEST_BHKNZ);
+        AdditionalCredentials credentials = AdditionalCredentials.createWithBhknz(TEST_BHKNZ);
 
         assertFalse(credentials.hasUsernamePassword());
     }
 
     @Test
     public void testHasBhknzNullBhknz() {
-        AdditionalCredentials credentials = AdditionalCredentials.withUsernamePassword(TEST_USERNAME, TEST_PASSWORD);
+        AdditionalCredentials credentials = AdditionalCredentials.createWithUsernamePassword(TEST_USERNAME, TEST_PASSWORD);
 
         assertFalse(credentials.hasBhknz());
     }

--- a/isy-security/src/test/java/de/bund/bva/isyfact/security/oauth2/client/AuthentifizierungsmanagerTest.java
+++ b/isy-security/src/test/java/de/bund/bva/isyfact/security/oauth2/client/AuthentifizierungsmanagerTest.java
@@ -108,7 +108,7 @@ public class AuthentifizierungsmanagerTest extends AbstractOidcProviderTest {
 
     @Test
     public void testAuthWithRegistrationIdAndBhknz() {
-        AdditionalCredentials credentials = AdditionalCredentials.withBhknz("900600");
+        AdditionalCredentials credentials = AdditionalCredentials.createWithBhknz("900600");
 
         authentifizierungsmanager.authentifiziere("cc-client", credentials);
 
@@ -123,7 +123,7 @@ public class AuthentifizierungsmanagerTest extends AbstractOidcProviderTest {
 
     @Test
     public void testAuthWithRegistrationIdAndUsernamePassword() {
-        AdditionalCredentials credentials = AdditionalCredentials.withUsernamePassword("newUser", "newPassword");
+        AdditionalCredentials credentials = AdditionalCredentials.createWithUsernamePassword("newUser", "newPassword");
 
         authentifizierungsmanager.authentifiziere("ropc-client", credentials);
 
@@ -151,7 +151,7 @@ public class AuthentifizierungsmanagerTest extends AbstractOidcProviderTest {
 
     @Test
     public void testAuthWithUnknownRegistrationIdAndCredentials() {
-        AdditionalCredentials credentials = AdditionalCredentials.withBhknz("900600");
+        AdditionalCredentials credentials = AdditionalCredentials.createWithBhknz("900600");
 
         assertThrows(IllegalArgumentException.class,
                 () -> authentifizierungsmanager.authentifiziere("unknown-clientId", credentials));
@@ -160,7 +160,7 @@ public class AuthentifizierungsmanagerTest extends AbstractOidcProviderTest {
     @Test
     public void testAuthWithRegistrationIdAndUsernamePasswordBhknz() {
         //override credentials
-        AdditionalCredentials credentials = AdditionalCredentials.withUsernamePasswordBhknz(
+        AdditionalCredentials credentials = AdditionalCredentials.createWithUsernamePasswordBhknz(
                 "newUser", "newPassword", "900600");
 
         authentifizierungsmanager.authentifiziere("ropc-client", credentials);
@@ -214,7 +214,7 @@ public class AuthentifizierungsmanagerTest extends AbstractOidcProviderTest {
                 .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
                 .build();
 
-        AdditionalCredentials additionalCredentials = AdditionalCredentials.withBhknz("900600");
+        AdditionalCredentials additionalCredentials = AdditionalCredentials.createWithBhknz("900600");
 
         authentifizierungsmanager.authentifiziere(clientRegistration, additionalCredentials);
 
@@ -241,7 +241,7 @@ public class AuthentifizierungsmanagerTest extends AbstractOidcProviderTest {
                 .authorizationGrantType(AuthorizationGrantType.PASSWORD)
                 .build();
 
-        AdditionalCredentials additionalCredentials = AdditionalCredentials.withUsernamePassword("newUser", "newUser");
+        AdditionalCredentials additionalCredentials = AdditionalCredentials.createWithUsernamePassword("newUser", "newUser");
 
         authentifizierungsmanager.authentifiziere(clientRegistration, additionalCredentials);
 
@@ -270,7 +270,7 @@ public class AuthentifizierungsmanagerTest extends AbstractOidcProviderTest {
                 .authorizationGrantType(AuthorizationGrantType.PASSWORD)
                 .build();
 
-        AdditionalCredentials additionalCredentials = AdditionalCredentials.withUsernamePasswordBhknz(
+        AdditionalCredentials additionalCredentials = AdditionalCredentials.createWithUsernamePasswordBhknz(
                 "newUser", "newPassword", "900600");
 
         authentifizierungsmanager.authentifiziere(clientRegistration, additionalCredentials);
@@ -314,7 +314,7 @@ public class AuthentifizierungsmanagerTest extends AbstractOidcProviderTest {
                 .authorizationGrantType(AuthorizationGrantType.PASSWORD)
                 .build();
 
-        AdditionalCredentials credentials = AdditionalCredentials.withBhknz("900600");
+        AdditionalCredentials credentials = AdditionalCredentials.createWithBhknz("900600");
 
         assertThrows(BadCredentialsException.class,
                 () -> authentifizierungsmanager.authentifiziere(clientRegistration, credentials));
@@ -330,7 +330,7 @@ public class AuthentifizierungsmanagerTest extends AbstractOidcProviderTest {
                 .authorizationGrantType(AuthorizationGrantType.DEVICE_CODE)
                 .build();
 
-        AdditionalCredentials credentials = AdditionalCredentials.withUsernamePassword("username", "password");
+        AdditionalCredentials credentials = AdditionalCredentials.createWithUsernamePassword("username", "password");
 
         assertThrows(IllegalArgumentException.class,
                 () -> authentifizierungsmanager.authentifiziere(clientRegistration, credentials));
@@ -338,7 +338,7 @@ public class AuthentifizierungsmanagerTest extends AbstractOidcProviderTest {
 
     @Test
     public void testAuthWithNullClientRegistrationAndValidCredentials() {
-        AdditionalCredentials credentials = AdditionalCredentials.withBhknz("900600");
+        AdditionalCredentials credentials = AdditionalCredentials.createWithBhknz("900600");
 
         assertThrows(IllegalArgumentException.class,
                 () -> authentifizierungsmanager.authentifiziere((String) null, credentials));

--- a/isy-security/src/test/java/de/bund/bva/isyfact/security/oauth2/client/AuthentifizierungsmanagerWithoutClientsConfiguredTest.java
+++ b/isy-security/src/test/java/de/bund/bva/isyfact/security/oauth2/client/AuthentifizierungsmanagerWithoutClientsConfiguredTest.java
@@ -2,6 +2,7 @@ package de.bund.bva.isyfact.security.oauth2.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
@@ -17,10 +18,12 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
 import de.bund.bva.isyfact.security.AbstractOidcProviderTest;
+import de.bund.bva.isyfact.security.config.AdditionalCredentials;
 import de.bund.bva.isyfact.security.oauth2.client.authentication.ClientCredentialsClientRegistrationAuthenticationProvider;
 import de.bund.bva.isyfact.security.oauth2.client.authentication.PasswordClientRegistrationAuthenticationProvider;
 import de.bund.bva.isyfact.security.oauth2.client.authentication.token.ClientCredentialsClientRegistrationAuthenticationToken;
@@ -103,6 +106,59 @@ public class AuthentifizierungsmanagerWithoutClientsConfiguredTest extends Abstr
         assertEquals("testuser", value.getUsername());
         assertEquals("pw", value.getPassword());
         assertEquals("123456", value.getBhknz());
+
+        assertEquals(mockJwt, SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    public void testAuthWithDirectClientRegistration() {
+        ClientRegistration clientRegistration = ClientRegistration.withRegistrationId("custom-cc-client")
+                .tokenUri("http://localhost:9095/auth/realms/testrealm/protocol/openid-connect/token")
+                .jwkSetUri("http://localhost:9095/auth/realms/testrealm/protocol/openid-connect/certs")
+                .clientId("testid")
+                .clientSecret("testsecret")
+                .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+                .build();
+
+        authentifizierungsmanager.authentifiziere(clientRegistration);
+
+        ArgumentCaptor<ClientCredentialsClientRegistrationAuthenticationToken> tokenCaptor =
+                ArgumentCaptor.forClass(ClientCredentialsClientRegistrationAuthenticationToken.class);
+        verify(clientCredentialsClientRegistrationAuthenticationProvider).authenticate(tokenCaptor.capture());
+        ClientCredentialsClientRegistrationAuthenticationToken value = tokenCaptor.getValue();
+        assertEquals("custom-cc-client", value.getClientRegistration().getRegistrationId());
+        assertEquals("testid", value.getClientRegistration().getClientId());
+        assertEquals("testsecret", value.getClientRegistration().getClientSecret());
+        assertNull(value.getBhknz());
+
+        assertEquals(mockJwt, SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    public void testAuthWithDirectClientRegistrationAndCredentials() {
+        ClientRegistration clientRegistration = ClientRegistration.withRegistrationId("custom-ropc-client")
+                .tokenUri("http://localhost:9095/auth/realms/testrealm/protocol/openid-connect/token")
+                .jwkSetUri("http://localhost:9095/auth/realms/testrealm/protocol/openid-connect/certs")
+                .clientId("testid")
+                .clientSecret("testsecret")
+                .authorizationGrantType(AuthorizationGrantType.PASSWORD)
+                .build();
+
+        AdditionalCredentials additionalCredentials = AdditionalCredentials.withUsernamePasswordBhknz(
+                "newUser", "newPassword", "900600");
+
+        authentifizierungsmanager.authentifiziere(clientRegistration, additionalCredentials);
+
+        ArgumentCaptor<PasswordClientRegistrationAuthenticationToken> tokenCaptor =
+                ArgumentCaptor.forClass(PasswordClientRegistrationAuthenticationToken.class);
+        verify(passwordClientRegistrationAuthenticationProvider).authenticate(tokenCaptor.capture());
+        PasswordClientRegistrationAuthenticationToken value = tokenCaptor.getValue();
+        assertEquals("custom-ropc-client", value.getClientRegistration().getRegistrationId());
+        assertEquals("testid", value.getClientRegistration().getClientId());
+        assertEquals("testsecret", value.getClientRegistration().getClientSecret());
+        assertEquals("newUser", value.getUsername());
+        assertEquals("newPassword", value.getPassword());
+        assertEquals("900600", value.getBhknz());
 
         assertEquals(mockJwt, SecurityContextHolder.getContext().getAuthentication());
     }

--- a/isy-security/src/test/java/de/bund/bva/isyfact/security/oauth2/client/AuthentifizierungsmanagerWithoutClientsConfiguredTest.java
+++ b/isy-security/src/test/java/de/bund/bva/isyfact/security/oauth2/client/AuthentifizierungsmanagerWithoutClientsConfiguredTest.java
@@ -144,7 +144,7 @@ public class AuthentifizierungsmanagerWithoutClientsConfiguredTest extends Abstr
                 .authorizationGrantType(AuthorizationGrantType.PASSWORD)
                 .build();
 
-        AdditionalCredentials additionalCredentials = AdditionalCredentials.withUsernamePasswordBhknz(
+        AdditionalCredentials additionalCredentials = AdditionalCredentials.createWithUsernamePasswordBhknz(
                 "newUser", "newPassword", "900600");
 
         authentifizierungsmanager.authentifiziere(clientRegistration, additionalCredentials);

--- a/isy-task/pom.xml
+++ b/isy-task/pom.xml
@@ -74,6 +74,12 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-client</artifactId>
+            <!-- only required if the application wants to authenticate clients -->
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-security/images/konzept/security-schnittstellen.dn.png
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-security/images/konzept/security-schnittstellen.dn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:286da2bb873bfeb7318c6c7925a7c3f70adb318c867e66a8d18cca5260f5d305
+size 57258

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-security/images/konzept/security-schnittstellen.dn.svg
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-security/images/konzept/security-schnittstellen.dn.svg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:94b7e5f17c11b38afa45a52777c1d2b05ab1312a2c346fbda05b9ff308627756
-size 7689

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/konzept/inhalt.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/konzept/inhalt.adoc
@@ -89,7 +89,7 @@ Im Folgenden wird die Schnittstelle des Bausteins `isy-security` beschrieben.
 
 .Schnittstelle des Bausteins Security
 [id="image-schnittstelle-security",reftext="{figure-caption} {counter:figures}"]
-image::konzept/security-schnittstellen.dn.svg[align="center"]
+image::konzept/security-schnittstellen.dn.png[align="center"]
 
 Das Interface `Security` ist der zentrale Einstiegspunkt in den Baustein `isy-security`.
 Bei seiner Instanziierung wird die anwendungsspezifische Rollen-Rechte-Datei eingelesen und damit der `Authentifizierungsmanager` sowie der `Berechtigungsmanager` erzeugt.
@@ -101,6 +101,7 @@ Der `Authentifizierungsmanager` übernimmt die programmatische Authentifizierung
 Batches und Tasks sind als Confidential Client eingestuft und verwahren ihre Authentifizierungsdaten (entweder Client-ID u. Client-Secret oder Nutzername u. Passwort) in ihrer Konfiguration (mit einer `oauth2ClientRegistrationId` als Schlüssel).
 Die Methode `authentifiziere(oauth2ClientRegistrationId)` im Authentifizierungsmanager liest diese Authentifizierungsdaten aus der betrieblichen Konfiguration und führt damit eine OAuth2.0-konforme Authentifizierung und Autorisierung der Anwendung gegenüber dem IAM-System durch.
 Dabei wird anhand des Typs der Authentifizierungsdaten der passende Authentication-Flow mit den konfigurierten Authentifizierungsdaten verwendet.
+Mit der Methode `authentifiziere(String oauth2ClientRegistrationId, AdditionalCredentials credentials)` können die zur `oauth2ClientRegistrationId` gehörenden Benutzerdaten mit den `AdditionalCredentials` überschrieben werden.
 
 xref:glossary::terms-definitions.adoc#externes-system[Externe Systeme] übermitteln ihre Authentifizierungsdaten (entweder Client-ID u. Client-Secret oder Nutzername u. Passwort) mit im Header der HTTP-Anfrage an das Service-Gateway bzw. Authentication-Gateway.
 Das Gateway führt damit eine OAuth2.0-konforme Authentifizierung und Autorisierung des Systems gegenüber dem IAM-System durch.
@@ -111,6 +112,36 @@ Hierbei ist zu beachten, dass aktuell keine Auswertung bzw. Weiterleitung des BH
 
 - Für den Credential-Typ bzw. _Credential_-Flow xref:resource-owner-password-credential-flow[] die Methode `authentifiziereSystem` mit den Parametern `issuerLocation` als URI des IAM, `clientId` und `clientSecret` des Gateways als vermittelnden _confidential client_ sowie `username`, `password` und optional das BHKNZ der externen Anwendung.
 
+- Für den Credential-Typ bzw. _Credential_-Flow xref:client-credential-flow[] sind folgende Methoden verfügbar:
+* `authentifiziere(String oauth2ClientRegistrationId)`: Nutzt die in der Anwendungskonfiguration hinterlegte Client-Registration mit der angegebenen ID. Die Client-ID und das Client-Secret werden aus der Konfiguration gelesen.
+* `authentifiziere(String oauth2ClientRegistrationId, AdditionalCredentials credentials)`: Wie oben, ermöglicht jedoch die Angabe eines BHKNZ über die AdditionalCredentials.
+* `authentifiziere(ClientRegistration clientRegistration)`: Erlaubt die direkte Verwendung eines ClientRegistration-Objekts mit Token-URI und JWKS-URI.
+* `authentifiziere(ClientRegistration clientRegistration, AdditionalCredentials credentials)`: Wie oben, ergänzt um die Möglichkeit, ein BHKNZ über die AdditionalCredentials anzugeben.
+* `authentifiziereClient-Methoden`: Sind zu verwenden mit der `issuerLocation` als URI des IAM sowie `clientId`, `clientSecret` und optional das BHKNZ des externen Systems als Parameter.
+Hierbei ist zu beachten, dass aktuell keine Auswertung bzw. Weiterleitung des BHKNZ an das IAM stattfindet.
+
+- Für den Credential-Typ bzw. _Credential_-Flow xref:resource-owner-password-credential-flow[] sind folgende Methoden verfügbar:
+* `authentifiziere(String oauth2ClientRegistrationId)`: Nutzt die in der Anwendungskonfiguration hinterlegte Client-Registration mit der angegebenen ID. Benutzername und Passwort müssen in der Konfiguration konfiguriert sein.
+* `authentifiziere(String oauth2ClientRegistrationId, AdditionalCredentials credentials)`: Ermöglicht die Verwendung dynamischer Benutzeranmeldedaten zur Laufzeit. Die AdditionalCredentials müssen Benutzername und Passwort enthalten und überschreiben ggf. in der Konfiguration hinterlegte Werte.
+* `authentifiziere(ClientRegistration clientRegistration, AdditionalCredentials credentials)`: Erlaubt die vollständig dynamische Authentifizierung mit einem selbst erstellten ClientRegistration-Objekt und Benutzerdaten. Die AdditionalCredentials müssen Benutzername und Passwort enthalten.
+* `authentifiziereSystem-Methoden`: Sind zu verwenden mit den Parametern `issuerLocation` als URI des IAM, `clientId` und `clientSecret` des Gateways als vermittelnden _confidential client_ sowie `username`, `password` und optional das BHKNZ der externen Anwendung.
+
+****
+*Anmerkung zur Deprecation*
+
+Die Methoden `authentifiziereClient` und `authentifiziereSystem` und ihre überladenen Varianten sind als deprecated markiert und sollten nicht mehr verwendet werden. In künftigen Versionen werden diese Methoden nicht mehr vorhanden sein.
+****
+
+Die Klasse `AdditionalCredentials` dient zur Kapselung zusätzlicher Authentifizierungsdaten bei der Authentifizierung mit ClientRegistration-Objekten.
+Sie ermöglicht die flexible Kombination verschiedener Credentials wie Benutzername, Passwort und BHKNZ.
+Über statische Builder-Methoden können Instanzen mit den gewünschten Kombinationen erstellt werden:
+
+- `withUsernamePassword` für Benutzername und Passwort,
+- `withUsernamePasswordBhknz` für Benutzername, Passwort und BHKNZ, sowie
+- `withBhknz` nur für das BHKNZ.
+
+Die Klasse bietet zudem Prüfmethoden wie `hasUsernamePassword` und `hasBhknz`, um die Verfügbarkeit bestimmter Credentials zu ermitteln.
+
 Der `Berechtigungsmanager` gibt Auskunft über die Rollen und Rechte des Anwenders.
 Die in der Benutzeradministration dem Anwender zugewiesenen Rollen werden mithilfe einer anwendungsspezifischen Rollen-Rechte-Datei in konkrete Rechte des Anwenders für diese Anwendung umgewandelt.
 Die aktuellen Rollen und Rechte des Anwenders können mit den Methoden des `Berechtigungsmanager` erfragt werden und es kann geprüft werden, ob der Anwender ein bestimmtes Recht hat.
@@ -119,6 +150,32 @@ Mit der Methode `hatRecht` kann die Anwendung feststellen, ob der Anwender aktue
 Mit diesen Berechtigungsabfragen kann die Geschäftsanwendung z.B. feingranular bestimmen, ob und wie der Anwender bestimmte Daten sehen oder bearbeiten kann bzw. ob und wie er bestimmte Funktionen der Anwendung benutzen kann. +
 Ein beliebiges Attribut, das im Access-Token des Security Contexts abgelegt ist, kann mit der Methode `getTokenAttribute` gelesen werden. Mit dem Namen (String) des Attributes als Parameter liefert es den Wert des Attributes (Object).
 
+.Verwendung der Authentifizierungsverfahren
+====
+*Client Credentials Flow Beispiel*
+
+- Manuelle Konfiguration der tokenUri und jwkSetUri.
+[source,java]
+----
+
+ClientRegistration clientCredentialsRegistration = ClientRegistration.withRegistrationId("client-service")
+    .tokenUri("http://iam-provider/auth/realms/testrealm/protocol/openid-connect/token")
+    .jwkSetUri("http://iam-provider/auth/realms/testrealm/protocol/openid-connect/certs")
+    .clientId("client-id")
+    .clientSecret("client-secret")
+    .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+    .build();
+
+----
+
+*Einfache Authentifizierung mit ClientRegistration*
+[source,java]
+----
+
+authentifizierungsmanager.authentifiziere(clientCredentialsRegistration);
+
+----
+====
 
 [[aufruf-von-nachbarsystemen]]
 === Aufruf von Nachbarsystemen
@@ -301,11 +358,11 @@ aber ohne _Authentication-Gateway_ noch einmal verdeutlicht:
 image::konzept/Squenzdiagramm_ServiceGateway_ohne_AuthGateway.dn.svg[align="center"]
 
 Die Authentifizierung über das SGW (Service Gateway) stellt einen wichtigen Schritt in der Sicherung von Anwendungen dar.
-Um diesen Prozess effektiv umzusetzen, empfiehlt sich die Verwendung der Methode `authentifiziereClient` des neu entwickelten Authentifizierungsmanagers.
+Um diesen Prozess effektiv umzusetzen, empfiehlt sich die Verwendung der Methode `authentifiziere` des Authentifizierungsmanagers.
 Mit dessen Hilfe ist es möglich, den Client zu authentifizieren und sicherzustellen, dass nur autorisierte Clients Zugriff auf die Ressourcen erhalten.
 Durch die Nutzung dieses speziellen Authentifizierungsmechanismus wird eine robuste und zuverlässige Sicherheitsschicht implementiert, um unautorisierten Zugriff und potenzielle Sicherheitslücken zu verhindern.
 
-Weitere Informationen und detaillierte Anleitungen zur Verwendung der `authentifiziereClient`-Methode können in der entsprechenden Dokumentation des Authentifizierungsmanagers 
+Weitere Informationen und detaillierte Anleitungen zur Verwendung der `authentifiziere`-Methode können in der entsprechenden Dokumentation des Authentifizierungsmanagers
 oder in den xref:nutzungsvorgaben/inhalt.adoc#authentifizierungsmanager-interface[Nutzungsvorgaben] gefunden werden.
 
 

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/inhalt.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/inhalt.adoc
@@ -45,6 +45,19 @@ Für den `client_credentials` (_Client Credentials_ Flow) GrantType erfolgt unab
 eine erneute Authentifizierung nur dann, wenn das Token weniger als 60 Sekunden vor Ablauf steht.
 Dieser Wert ist als Standardwert durch eine Implementierung in Spring Security vorgegeben.
 
+`void authentifiziere(String oauth2ClientRegistrationId, AdditionalCredentials credentials)`::
+Authentifiziert einen OAuth 2.0 Client anhand seiner Client-Registration-ID mit zusätzlichen dynamischen Authentifizierungsdaten. Unterstützt:
+* `client_credentials`-GrantType: Hier kann ein BHKNZ über die AdditionalCredentials übergeben werden.
+* `password`-GrantType: Hier können Benutzername und Passwort, sowie optional das BHKNZ übergeben werden. Diese Authentifizierungsdaten werden anstelle der eventuell in der Konfiguration hinterlegten Werte verwendet.
+
+`void authentifiziere(ClientRegistration clientRegistration)`::
+Authentifiziert einen OAuth 2.0 Client anhand des übergebenen ClientRegistration-Objektes. Diese Methode unterstützt ausschließlich den `client_credentials`-GrantType (_Client Credentials_ Flow).
+
+`void authentifiziere(ClientRegistration clientRegistration, AdditionalCredentials credentials)`::
+Authentifiziert einen OAuth 2.0 Client anhand des übergebenen ClientRegistration-Objektes mit zusätzlichen dynamischen Authentifizierungsdaten. Unterstützt beide Grant-Types:
+* `client_credentials`-GrantType: Hier kann ein BHKNZ über die AdditionalCredentials übergeben werden.
+* `password`-GrantType: Hier *müssen* Benutzername und Passwort in den AdditionalCredentials enthalten sein, da sie nicht aus der Konfiguration geladen werden können.
+
 `void authentifiziereClient(String issuerLocation, String clientId, String clientSecret)`::
 `void authentifiziereClient(String issuerLocation, String clientId, String clientSecret, String bhknz)`::
 Authentifiziert einen OAuth 2.0 Client gegen die angegebene `issuerLocation` anhand seiner `clientId` und `clientSecret`.
@@ -54,6 +67,49 @@ Das `bhknz` kann als optionaler Parameter übergeben werden, wird aber für die 
 `void authentifiziereSystem(String issuerLocation, String clientId, String clientSecret, String username, String password, String bhknz)`::
 Authentifiziert einen technischen Nutzer (Resource Owner) gegen die angegebene `issuerLocation` anhand der `clientId` und `clientSecret` des zu verwendenden OAuth 2.0 Clients und dem `username` und `password` des Resource Owners.
 Das `bhknz` kann als optionaler Parameter übergeben werden und wird in den <<isyfact-specific-client-registration,konfigurierten Header>> zur Zwei-Faktor-Authentifizierung gesetzt.
+
+[NOTE]
+Die Methoden authentifiziereClient und authentifiziereSystem und ihre überladenen Varianten sind als deprecated markiert und sollten nicht mehr erwendet werden. In künftigen Versionen werden diese Methoden nicht mehr vorhanden sein.
+
+.Verwendung der Authentifizierungsverfahren
+[source,java]
+----
+//Client Credentials Flow Beispiel*
+ClientRegistration clientCredentialsRegistration = ClientRegistration.withRegistrationId("client-service")
+.tokenUri("http://iam-provider/auth/realms/testrealm/protocol/openid-connect/token")
+.jwkSetUri("http://iam-provider/auth/realms/testrealm/protocol/openid-connect/certs")
+.clientId("client-id")
+.clientSecret("client-secret")
+.authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+.build();
+
+//Einfache Authentifizierung mit ClientRegistration
+authentifizierungsmanager.authentifiziere(clientCredentialsRegistration);
+
+//Einfache Authentifizierung mit ClientRegistration inkl. BHKNZ
+AdditionalCredentials credentialsWithBhknz = AdditionalCredentials.withBhknz("123456");
+authentifizierungsmanager.authentifiziere(clientCredentialsRegistration, credentialsWithBhknz);
+
+//Resource Owner Password Credentials Flow Beispiel
+ClientRegistration passwordFlowRegistration = ClientRegistration.withRegistrationId("sgw-service")
+.tokenUri("http://iam-provider/auth/realms/testrealm/protocol/openid-connect/token")
+.jwkSetUri("http://iam-provider/auth/realms/testrealm/protocol/openid-connect/certs")
+.clientId("sgw-client")
+.clientSecret("sgw-secret")
+.authorizationGrantType(AuthorizationGrantType.PASSWORD)
+.build();
+
+//Authentifizierung mit AdditionalCredentials: username und password*
+AdditionalCredentials credentialsWithUsernamePassword = AdditionalCredentials.withUsernamePassword("user", "passwort");
+authentifizierungsmanager.authentifiziere(passwordFlowRegistration, credentialsWithUsernamePassword);
+
+//Authentifizierung mit AdditionalCredentials: username, password und BHKNZ*
+AdditionalCredentials credentialsWithUsernamePasswordBhknz = AdditionalCredentials.withUsernamePasswordBhknz(
+"user", "passwort", "123456");
+authentifizierungsmanager.authentifiziere(passwordFlowRegistration, credentialsWithUsernamePasswordBhknz);
+
+----
+
 
 [[berechtigungsmanager]]
 === Berechtigungsmanager


### PR DESCRIPTION
* feat: IFS-4591 mark 'authentifiziereClient' and 'authentifiziereSystem'-methods as deprecated
* feat: IFS-4591 add AdditionalCredentials used for some authentication methods
* feat: IFS-4591 add new 'authentifiziere'-methods which allow authentication without issuer uri
* test: IFS-4591 add test cases for new 'authentifiziere'-methods
* test: IFS-4591 add test cases for AdditionalCredentials
* chore: IFS-4591 add optional dependency 'spring-security-oauth2-client' to isy-task as it is needed for proper building
* docs: IFS-4591 add documentation for new 'authentifiziere'-methods and point out that 'authentifiziereClient' and 'authentifiziereSystem' are marked as deprecated; reformat SVG image in PNG
* refactor: IFS-4591 rename method names to make clear what they do
* chore: IFS-4591 add CHANGELOG.md entry