### PR TITLE
[Sprint 126] IFS-4464 Definition of auto configuration of class MdcFilterAutoConfiguration is swapped to isy-logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   Hiermit wird ein ähnliches Verhalten zu einem unauthentifizierten AufrufKontext wiederhergestellt.
 - `IFS-4316`: [isyfact-products-bom] Aktualisierung und Bereitstellung des Produktkatalogs der Isyfact.
 - `IFS-4495`: [isy-task] Verwendung der Defaults falls keine Task-Config definiert ist
+- `IFS-4464`: [isy-aufrufkontext, isy-logging] AutoConfiguration der Klasse MdcFilterAutoConfiguration ist in isy-logging definiert
 
 ### Bug Fixes
 - `IFS-4514`: [isyfact-standards-doc] Build-Fehler und ungültige Verweise auf externe Websites korrigiert.

--- a/isy-aufrufkontext/CHANGELOG.md
+++ b/isy-aufrufkontext/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.3.0
+### Features
+- `IFS-4464`: AutoConfiguration der Klasse MdcFilterAutoConfiguration nach isy-logging verschoben
+
 # 3.1.0
 - `IFS-3612`: Bibliothek als `@Deprecated` markiert
   - Nach Umstellung auf `isy-security` und REST Schnittstellen wird die Bibliothek nicht länger benötigt.

--- a/isy-aufrufkontext/src/main/resources/META-INF/spring.factories
+++ b/isy-aufrufkontext/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-de.bund.bva.isyfact.logging.autoconfigure.MdcFilterAutoConfiguration

--- a/isy-logging/CHANGELOG.md
+++ b/isy-logging/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.3.0
+### Features
+- `IFS-4464`: AutoConfiguration der Klasse MdcFilterAutoConfiguration nach isy-logging verschoben
+
 # 3.0.0
 - `ISY-650`: Bean zum Setzen der Korrelations-ID angepasst:
     * `HttpHeaderNestedDiagnosticContextFilter` aus `isy-aufrufkontext` eingefügt

--- a/isy-logging/src/main/resources/META-INF/spring.factories
+++ b/isy-logging/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,4 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 de.bund.bva.isyfact.logging.autoconfigure.IsyLoggingAutoConfiguration,\
-de.bund.bva.isyfact.logging.autoconfigure.IsyPerformanceLoggingAutoConfiguration
+de.bund.bva.isyfact.logging.autoconfigure.IsyPerformanceLoggingAutoConfiguration,\
+de.bund.bva.isyfact.logging.autoconfigure.MdcFilterAutoConfiguration


### PR DESCRIPTION
* chore: Definition of auto configuration of class MdcFilterAutoConfiguration is swapped to isy-logging