### PR TITLE
[Sprint 127] IFS-4676 set scope of aspectJ-weaver dependency to runtime 5.x

### DIFF
--- a/isy-logging/CHANGELOG.md
+++ b/isy-logging/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.0.0
+- `IFS-4676`: Scope der Abhängigkeit zu AspectJ-Weaver auf Runtime gesetzt.
+  * Definitionen der Aspekte zum kompilieren werden von org.aspectj:aspectjrt bereitgestellt.
+
 # 4.0.0
 - `IFS-4452`: Logging Autoconfiguration aus dem isy-aufrufkontext (in 4.0.0 nicht mehr vorhanden) hier eingeführt:
     * `de.bund.bva.isyfact.logging.autoconfigure.MdcFilterAutoConfiguration` in `org.springframework.boot.autoconfigure.AutoConfiguration.imports` eingefügt

--- a/isy-logging/pom.xml
+++ b/isy-logging/pom.xml
@@ -80,7 +80,7 @@
             <artifactId>logback-core</artifactId>
         </dependency>
         <dependency>
-            <groupId> org.slf4j</groupId>
+            <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
@@ -89,7 +89,13 @@
         </dependency>
         <dependency>
             <groupId>org.aspectj</groupId>
+            <artifactId>aspectjrt</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.aspectj</groupId>
             <artifactId>aspectjweaver</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.validation</groupId>


### PR DESCRIPTION
- `IFS-4676`: Scope der Abhängigkeit zu AspectJ-Weaver auf Runtime gesetzt.
    * Definitionen der Aspekte zum kompilieren werden von org.aspectj:aspectjrt bereitgestellt.