### PR TITLE
[Sprint 127] IFS-4676 set scope of aspectJ-weaver dependency to runtime 4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - `IFS-4549`: [isyfact-standards-doc] Verwaltung von Versionen zentralisiert
 - `IFS-4584`: [isyfact-standards-doc] Entfernung von `isy-asciidoctorj-extensions`
 - `IFS-4591`: [isy-security] Hinzufügen von Authentifizierungsmethoden zur Authentifizierung von Clients und Systemen ohne Issuer-URI.
+- `IFS-4676`: [isy-task], [isy-logging] Scope der Abhängigkeit zu AspectJ-Weaver auf Runtime gesetzt.
+    * Definitionen der Aspekte zum kompilieren werden von org.aspectj:aspectjrt bereitgestellt.
 
 ## BUG FIXES
 - `IFS-4526`: [isy-task] Logeintrag IsyTaskAspect korrigiert

--- a/isy-logging/CHANGELOG.md
+++ b/isy-logging/CHANGELOG.md
@@ -1,9 +1,13 @@
+# 4.1.0
+- `IFS-4676`: Scope der Abhängigkeit zu AspectJ-Weaver auf Runtime gesetzt.
+    * Definitionen der Aspekte zum kompilieren werden von org.aspectj:aspectjrt bereitgestellt.
+
 # 4.0.0
 - `IFS-4452`: Logging Autoconfiguration aus dem isy-aufrufkontext (in 4.0.0 nicht mehr vorhanden) hier eingeführt:
     * `de.bund.bva.isyfact.logging.autoconfigure.MdcFilterAutoConfiguration` in `org.springframework.boot.autoconfigure.AutoConfiguration.imports` eingefügt
     * In Spring Boot 3 wird META-INF/spring.factories nicht mehr verwendet und durch META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports ersetzt
 - `IFS-3740`: IsyFact-Standards IF4: Analyse: Stabilität der Tests wiederherstellen
-  
+
 # 3.0.0
 - `ISY-650`: Bean zum Setzen der Korrelations-ID angepasst:
     * `HttpHeaderNestedDiagnosticContextFilter` aus `isy-aufrufkontext` eingefügt

--- a/isy-logging/pom.xml
+++ b/isy-logging/pom.xml
@@ -80,7 +80,7 @@
             <artifactId>logback-core</artifactId>
         </dependency>
         <dependency>
-            <groupId> org.slf4j</groupId>
+            <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
@@ -89,7 +89,13 @@
         </dependency>
         <dependency>
             <groupId>org.aspectj</groupId>
+            <artifactId>aspectjrt</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.aspectj</groupId>
             <artifactId>aspectjweaver</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.validation</groupId>

--- a/isy-task/CHANGELOG.md
+++ b/isy-task/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 4.1.0
 - `IFS-4526`: isy-task - Logeintrag IsyTaskAspect korrigiert
 - `IFS-4495`: Verwendung der Defaults falls keine Task-Config definiert ist
+- `IFS-4676`: Scope der Abhängigkeit zu AspectJ-Weaver auf Runtime gesetzt.
+    * Definitionen der Aspekte zum kompilieren werden von org.aspectj:aspectjrt bereitgestellt.
 
 # 4.0.0
 - `IFS-2395`: Umstellung von IsyFact `MessageSourceHolder` auf Spring `MessageSource`

--- a/isy-task/pom.xml
+++ b/isy-task/pom.xml
@@ -85,7 +85,13 @@
         </dependency>
         <dependency>
             <groupId>org.aspectj</groupId>
+            <artifactId>aspectjrt</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.aspectj</groupId>
             <artifactId>aspectjweaver</artifactId>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
- `IFS-4676`: Scope der Abhängigkeit zu AspectJ-Weaver auf Runtime gesetzt.
    * Definitionen der Aspekte zum kompilieren werden von org.aspectj:aspectjrt bereitgestellt.