### PR TITLE
Dependabot Update from Daily to Weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -168,7 +168,7 @@ updates:
     target-branch: "release/4.x"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "ci"
 


### PR DESCRIPTION
ci: update dependabot.yml to change automatic updates from daily to weekly for release/4.x