### PR TITLE
[Sprint 129] IFS-4715 Health-Endpunkt ohne Autorisierung 3.x

### DIFF
--- a/isy-ueberwachung/CHANGELOG.md
+++ b/isy-ueberwachung/CHANGELOG.md
@@ -3,6 +3,7 @@
 - `IFS-1629`: Standardmechanismus zur Absicherung der Actuator-Endpunkte auf Basis von WebSecurityConfigurerAdapter wurde bereitgestellt. Aktivieren durch das Setzen der Konfigurationsparameter:
     * `isy.ueberwachung.security.username=<username>`
     * `isy.ueberwachung.security.password=<password>`
+- `IFS-4715`: Öffnung des Health-Endpunkts ohne Autorisierung
 
 # 3.0.0
 - `IFS-1702`: Refaktorierung ServiceStatistik

--- a/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/autoconfigure/IsyActuatorSecurityAutoConfiguration.java
+++ b/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/autoconfigure/IsyActuatorSecurityAutoConfiguration.java
@@ -1,6 +1,7 @@
 package de.bund.bva.isyfact.ueberwachung.autoconfigure;
 
 import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
+import org.springframework.boot.actuate.health.HealthEndpoint;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -79,9 +80,9 @@ public class IsyActuatorSecurityAutoConfiguration {
 
         @Override
         protected void configure(HttpSecurity http) throws Exception {
-            http.requestMatcher(EndpointRequest.toAnyEndpoint())
+            http.securityMatcher(EndpointRequest.toAnyEndpoint())
                 .authorizeHttpRequests(requests -> requests
-                    .antMatchers("/actuator/health").permitAll()
+                    .requestMatchers(EndpointRequest.to(HealthEndpoint.class)).permitAll()
                     .anyRequest().hasRole(ENDPOINT_ROLE))
                 .httpBasic();
         }

--- a/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/autoconfigure/IsyActuatorSecurityAutoConfiguration.java
+++ b/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/autoconfigure/IsyActuatorSecurityAutoConfiguration.java
@@ -80,7 +80,9 @@ public class IsyActuatorSecurityAutoConfiguration {
         @Override
         protected void configure(HttpSecurity http) throws Exception {
             http.requestMatcher(EndpointRequest.toAnyEndpoint())
-                .authorizeHttpRequests(requests -> requests.anyRequest().hasRole(ENDPOINT_ROLE))
+                .authorizeHttpRequests(requests -> requests
+                    .antMatchers("/actuator/health").permitAll()
+                    .anyRequest().hasRole(ENDPOINT_ROLE))
                 .httpBasic();
         }
     }

--- a/isy-ueberwachung/src/test/java/de/bund/bva/isyfact/ueberwachung/actuate/health/HealthIntegrationSecurityTest.java
+++ b/isy-ueberwachung/src/test/java/de/bund/bva/isyfact/ueberwachung/actuate/health/HealthIntegrationSecurityTest.java
@@ -1,0 +1,89 @@
+package de.bund.bva.isyfact.ueberwachung.actuate.health;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import de.bund.bva.isyfact.ueberwachung.actuate.health.nachbarsystemcheck.model.NachbarsystemHealth;
+import de.bund.bva.isyfact.ueberwachung.autoconfigure.IsyHealthAutoConfiguration;
+
+@SpringBootTest(
+    classes = IsyHealthAutoConfiguration.class,
+    properties = {
+        "isy.logging.anwendung.name=HealthIntegrationTest",
+        "isy.logging.anwendung.version=1.0.0-SNAPSHOT",
+        "isy.logging.anwendung.typ=Integrationstest",
+        "isy.ueberwachung.security.username=test",
+        "isy.ueberwachung.security.password=123"
+    },
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@EnableAutoConfiguration
+public class HealthIntegrationSecurityTest {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @LocalServerPort
+    private int localPort;
+
+    @Test
+    void testMetricsRequiresAuthorization() {
+        Assertions.assertThatThrownBy(() -> getClientResponse("metrics"))
+            .isInstanceOf(HttpClientErrorException.class)
+            .hasStackTraceContaining("HTTP Status 401 – Unauthorized");
+    }
+
+    @Test
+    void testMetricsAvailableWithAuthorization() {
+        ResponseEntity<NachbarsystemHealth> responseEntity = getClientResponseWithAuth("metrics");
+        Assertions.assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void testInfoRequiresAuthorization() {
+        Assertions.assertThatThrownBy(() -> getClientResponse("info"))
+            .isInstanceOf(HttpClientErrorException.class)
+            .hasStackTraceContaining("HTTP Status 401 – Unauthorized");
+    }
+
+    @Test
+    void testInfoAvailableWithAuthorization() {
+        ResponseEntity<NachbarsystemHealth> responseEntity = getClientResponseWithAuth("info");
+        Assertions.assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void testHealthRequiresAuthorization() {
+        ResponseEntity<NachbarsystemHealth> responseEntity = getClientResponse("health");
+        Assertions.assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    private ResponseEntity<NachbarsystemHealth> getClientResponse(String endpoint, String... path) {
+        String p = "";
+        if (path != null) {
+            p = "/" + String.join("/", path);
+        }
+        String uri = "http://localhost:" + localPort + "/actuator/" + endpoint + p;
+
+        return restTemplate.getForEntity(uri, NachbarsystemHealth.class);
+    }
+
+    private ResponseEntity<NachbarsystemHealth> getClientResponseWithAuth(String endpoint, String... path) {
+        String p = "";
+        if (path != null) {
+            p = "/" + String.join("/", path);
+        }
+        String uri = "http://localhost:" + localPort + "/actuator/" + endpoint + p;
+
+        return new RestTemplateBuilder()
+            .basicAuthentication("test", "123")
+            .build()
+            .getForEntity(uri, NachbarsystemHealth.class);
+    }
+}

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-ueberwachung/pages/nutzungsvorgaben/inhalt.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-ueberwachung/pages/nutzungsvorgaben/inhalt.adoc
@@ -328,7 +328,8 @@ isy.task.tasks.isyHealthTask.fixed-delay=30s
 ===== Absicherung von Endpoints
 
 Der Zugriff auf Endpoints muss mit einer Authentifizierung abgesichert werden.
-Eine Standardkonfiguration für Spring Security, die alle Endpunkte mit HTTP Basic Authentication absichert, wird durch die Klasse `IsyActuatorSecurityAutoConfiguration` bereitgestellt.
+Hierbei ist die einzige Ausnahme der Health-Endpunkt, welcher keine Authentifizierung benötigt.
+Eine Standardkonfiguration für Spring Security, die alle anderen Endpunkte mit HTTP Basic Authentication absichert, wird durch die Klasse `IsyActuatorSecurityAutoConfiguration` bereitgestellt.
 
 Standardmäßig wird der Zugriff auf Endpunkte durch eine HTTP Basic Authentifizierung aktiviert, wenn die *Dependencies*:
 


### PR DESCRIPTION
* feat: IFS-4715 permit access to health endpoint in HttpBasicWebEndpointSecurityConfiguration
* feat: IFS-4715 replace deprecated spring security matchers
* feat: IFS-4715 add test class for endpoint access
* docs: IFS-4715 add changelog entry
* docs: IFS-4715 add mention about open health endpoint in docs