### PR TITLE
[Sprint 130] IFS-4733 sonatype mvn profiles

### DIFF
--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -57,7 +57,7 @@ jobs:
     with:
       version: ${{ github.ref_name }}
       maven-opts: '-P centralRelease'
-      deploy-server-id: ossrh
+      deploy-server-id: central
       sbom: true
       sign: true
       environment: 'Release'

--- a/.github/workflows/maven_release_force.yml
+++ b/.github/workflows/maven_release_force.yml
@@ -21,7 +21,7 @@ jobs:
     with:
       version: ${{ github.ref_name }}
       maven-opts: '-P centralRelease'
-      deploy-server-id: ossrh
+      deploy-server-id: central
       sbom: true
       sign: true
     secrets:

--- a/pom.xml
+++ b/pom.xml
@@ -731,49 +731,6 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>centralmavenrepo</id>
-            <activation>
-                <property>
-                    <name>centraldeploy</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <properties>
-            </properties>
-            <distributionManagement>
-                <snapshotRepository>
-                    <id>ossrh</id>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-                </snapshotRepository>
-                <repository>
-                    <id>ossrh</id>
-                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-                </repository>
-            </distributionManagement>
-        </profile>
-        <profile>
-            <id>internalmavenrepo</id>
-            <activation>
-                <property>
-                    <name>!centraldeploy</name>
-                </property>
-            </activation>
-            <properties>
-            </properties>
-            <distributionManagement>
-                <repository>
-                    <id>repository</id>
-                    <name>Repository</name>
-                    <url>${deploy-url-release}</url>
-                </repository>
-                <snapshotRepository>
-                    <id>repository</id>
-                    <name>Repository</name>
-                    <url>${deploy-url-snapshot}</url>
-                </snapshotRepository>
-            </distributionManagement>
-        </profile>
 
         <!-- remove if source code is adjusted to JDK 17 -->
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -579,37 +579,6 @@
                 </plugins>
             </build>
         </profile>
-        <!-- Profile to avoid SNAPSHOT-versions in releases. -->
-        <profile>
-            <id>release</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-enforcer-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>enforce-no-snapshots</id>
-                                <goals>
-                                    <goal>enforce</goal>
-                                </goals>
-                                <configuration>
-                                    <rules>
-                                        <requireReleaseDeps>
-                                            <message>Keine SNAPSHOT-Abhängigkeiten erlaubt!</message>
-                                        </requireReleaseDeps>
-                                        <requireReleaseVersion>
-                                            <message>Keine SNAPSHOT-Versionen erlaubt!</message>
-                                        </requireReleaseVersion>
-                                    </rules>
-                                    <fail>true</fail>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
         <profile>
             <!-- Moves the license files in APIDocs, if present. -->
             <id>copyLicenseFiles</id>
@@ -648,6 +617,30 @@
             <id>centralRelease</id>
             <build>
                 <plugins>
+                    <!-- Avoid SNAPSHOT-versions in releases. -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>enforce-no-snapshots</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireReleaseDeps>
+                                            <message>Keine SNAPSHOT-Abhängigkeiten erlaubt!</message>
+                                        </requireReleaseDeps>
+                                        <requireReleaseVersion>
+                                            <message>Keine SNAPSHOT-Versionen erlaubt!</message>
+                                        </requireReleaseVersion>
+                                    </rules>
+                                    <fail>true</fail>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -649,14 +649,13 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.13</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.7.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
* build: IFS-4733 adds central server for maven
* build: IFS-4733 adapts mvn plugin for release
* refactor: IFS-4733 removes unused mvn profiles
* refactor: IFS-4733 removes deploy server id
* refactor: IFS-4733 merges mvn profiles for releases
* refactor: IFS-4733 moves maven central settings in separate file