### PR TITLE
[Sprint 132] IFS-4791 metriken letzteMinute IF4.x

### DIFF
--- a/isy-ueberwachung/CHANGELOG.md
+++ b/isy-ueberwachung/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 4.1.0
 - `IFS-4534`: Bereitstellen von Metriken ohne Zeiteinschränkungen
 - `IFS-4715`: Öffnung des Health-Endpunkts ohne Autorisierung
+- `IFS-4791`: ServiceStatistik: Deprecation von Metriken mit Zeiteinschränkungen
 
 # 4.0.0
 - `ISY-888`: Freigabe des `/Loadbalancer` Endpunkts auf `SecurityFilterChain` (`@Order(99)`) umgestellt

--- a/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/metrics/ServiceStatistik.java
+++ b/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/metrics/ServiceStatistik.java
@@ -36,7 +36,11 @@ public interface ServiceStatistik {
 
     /**
      * Returns the number of calls counted in the last minute where no error occurred.
+     *
+     * @deprecated Will be removed in version 5.0.0.
+     * Consider using Prometheus for metric collection instead.
      */
+    @Deprecated(since = "4.1.0", forRemoval = true)
     int getAnzahlAufrufeLetzteMinute();
 
     /**
@@ -46,11 +50,19 @@ public interface ServiceStatistik {
 
     /**
      * Returns the number of calls in the last minute, in which an error occurred.
+     *
+     * @deprecated Will be removed in version 5.0.0.
+     * Consider using Prometheus for metric collection instead.
      */
+    @Deprecated(since = "4.1.0", forRemoval = true)
     int getAnzahlFehlerLetzteMinute();
 
     /**
      * Returns the number of calls in the last minute, in which a business error occurred.
+     *
+     * @deprecated Will be removed in version 5.0.0.
+     * Consider using Prometheus for metric collection instead.
      */
+    @Deprecated(since = "4.1.0", forRemoval = true)
     int getAnzahlFachlicheFehlerLetzteMinute();
 }

--- a/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/metrics/impl/DefaultServiceStatistik.java
+++ b/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/metrics/impl/DefaultServiceStatistik.java
@@ -36,10 +36,12 @@ public class DefaultServiceStatistik implements ServiceStatistik, MethodIntercep
     private static final IsyLogger LOG = IsyLoggerFactory.getLogger(DefaultServiceStatistik.class);
 
     /**
-     * Specifies whether the return object structures should be checked for business errors. May
-     * have an impact on performance.
+     * Specifies whether the return object structures should be checked for business errors.
+     * May have an impact on performance.
+     *
+     * @deprecated Will be removed in version 5.0.0.
      */
-    @Deprecated
+    @Deprecated(forRemoval = true)
     private boolean businessFehlerpruefung;
 
     /**
@@ -138,9 +140,11 @@ public class DefaultServiceStatistik implements ServiceStatistik, MethodIntercep
      * Specifies whether the return object structures should be checked for technical errors. May
      * have performance implications.
      *
+     * @deprecated Will be removed in version 5.0.0.
+     *
      * @param businessFehlerpruefung {@code true} if the return object structure should be checked for technical errors, otherwise {@code false}.
      */
-    @Deprecated
+    @Deprecated(forRemoval = true)
     public void setBusinessFehlerpruefung(boolean businessFehlerpruefung) {
         this.businessFehlerpruefung = businessFehlerpruefung;
     }

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-ueberwachung/pages/nutzungsvorgaben/inhalt.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-ueberwachung/pages/nutzungsvorgaben/inhalt.adoc
@@ -78,9 +78,9 @@ Die dort aufgelisteten Informationen müssen für jeden Service einzeln angebote
 m|AnzahlAufrufe |Liefert die Anzahl der erfolgten Aufrufe des Services insgesamt.
 m|AnzahlAufrufeLetzteMinute |Liefert die Anzahl der in der letzten Minute erfolgten Aufrufe des Services.
 m|AnzahlTechnicalExceptions |Liefert die gesamte Anzahl der erfolgten Aufrufe des Services, bei denen ein technischer Fehler aufgetreten ist.
-m|AnzahlTechnicalExceptionsLetzteMinute |Liefert die Anzahl der in der letzten Minute erfolgten Aufrufe des Services, bei denen ein technischer Fehler aufgetreten ist.
+m|AnzahlFehlerLetzteMinute |Liefert die Anzahl der in der letzten Minute erfolgten Aufrufe des Services, bei denen ein technischer Fehler aufgetreten ist.
 m|AnzahlBusinessExceptions |Liefert die gesamte Anzahl der erfolgten Aufrufe des Services, bei denen ein fachlicher Fehler aufgetreten ist.
-m|AnzahlBusinessExceptionsLetzteMinute |Liefert die Anzahl der in der letzten Minute erfolgten Aufrufe des Services, bei denen ein fachlicher Fehler aufgetreten ist.
+m|AnzahlFachlicheFehlerLetzteMinute |Liefert die Anzahl der in der letzten Minute erfolgten Aufrufe des Services, bei denen ein fachlicher Fehler aufgetreten ist.
 m|DurchschnittsDauerLetzteAufrufe |Liefert die durchschnittliche Bearbeitungsdauer der letzten 10 Aufrufe der Services in Millisekunden (einfacher gleitender Durchschnitt).
 |====
 

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-ueberwachung/pages/nutzungsvorgaben/inhalt.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-ueberwachung/pages/nutzungsvorgaben/inhalt.adoc
@@ -84,6 +84,9 @@ m|AnzahlFachlicheFehlerLetzteMinute |Liefert die Anzahl der in der letzten Minut
 m|DurchschnittsDauerLetzteAufrufe |Liefert die durchschnittliche Bearbeitungsdauer der letzten 10 Aufrufe der Services in Millisekunden (einfacher gleitender Durchschnitt).
 |====
 
+WARNING: Folgende Metriken werden in Version 5.0.0 entfernt: `AnzahlAufrufeLetzteMinute`, `AnzahlFehlerLetzteMinute`, `AnzahlFachlicheFehlerLetzteMinute`.
+Bei Bedarf können diese mit Prometheus-Queries nachgebildet werden.
+
 Das Interface `ServiceStatistik` ermöglicht es, Klassen zum Sammeln von Metriken zu erstellen.
 Alle `ServiceStatistik` implementierenden Beans werden automatisch der Micrometer-Registry hinzugefügt.
 


### PR DESCRIPTION
* chore: IFS-4791 deprecates "*letzteMinute" methods
* chore: IFS-4791 adds note for already deprecated field "businessFehlerpruefung"
* chore: IFS-4791 adds entry to CHANGELOG.md
* docs: IFS-4791 fixes metric names
* docs: IFS-4791 adds warning note for metrics