### PR TITLE
[Sprint 132] FS-4791 metriken letzteMinute

### DIFF
--- a/isy-ueberwachung/CHANGELOG.md
+++ b/isy-ueberwachung/CHANGELOG.md
@@ -1,51 +1,5 @@
-# 4.1.0
-- `IFS-4534`: Bereitstellen von Metriken ohne Zeiteinschränkungen
+# 5.0.0
+## FEATURES
+## BREAKING CHANGES
+- `IFS-4791`: Entfernt Metriken mit Zeiteinschränkungen
 
-# 4.0.0
-- `ISY-888`: Freigabe des `/Loadbalancer` Endpunkts auf `SecurityFilterChain` (`@Order(99)`) umgestellt
-- `ISY-601`: Standardabsicherung und Konfigurationsparameter werden per AutoConfiguration bereitgestellt.
-- `IFS-979`: Verbesserung der Nebenläufigkeit von DefaultServiceStatistik.
-- `IFS-4155`: Entfernung von obsoleten `pliscommon`-Ressourcen.
-  * Entfernung der Abhängigkeiten `de.bund.bva.isyfact.isy-exception-sst` und `de.bund.bva.isyfact.isy-serviceapi-sst`
-- `IFS-3740`: IsyFact-Standards IF4: Analyse: Stabilität der Tests wiederherstellen
-
-# 3.0.0
-- `IFS-1702`: Refaktorierung ServiceStatistik
-    * Entkoppelt von Micrometer API
-    * Aufgeteilt in Interface und Implementierung
-- `IFS-771`: Anleitung für den HealthCheck von HTTPInvoker-Endpoints hinzugefügt
-- `IFS-1628`: Standardmetriken bei Anbinden von ServiceStatistik vorhanden
-
-# 2.4.2
-- `IFS-1165`: Standardmäßig wird die "/Loadbalancer" Schnittstelle durch die Autokonfiguration freigegeben, wenn spring-security aktiviert ist.
-
-# 2.4.0
-- `IFS-686`: Property-Dateien auf Unicode Escapes umgestellt
-
-# 2.2.0
-- `IFS-453`: Loglevel für isAlive-Datei-Ereignisse erhöht: INFO für Standardablageort wird genutzt; ERROR für Datei existiert bei Abfrage nicht.
-- `IFS-656`: ServiceStatstik: Durchschnitt threadsafe berechnet
-
-# 2.1.0
-- `IFS-436`: Entkopplung Health-Endpoint und hinzufügen Nachbarsystem-Check
-- `IFS-687`: Umstellung des Nachbarsystem-Checks auf RestTemplate statt WebClient
-
-# 2.0.0
-- `IFS-228`: Einführung von Spring Boot
-- `IFS-32`: Package-Name auf de.bund.bva.isyfact geändert
-- `IFS-251`: Abhängigkeiten zu log4j entfernt
-
-# 1.9.0
-- `IFS-248`: Log-Level vom Start der Watchdog Prüfung auf debug gesetzt.
-- `IFS-347`: Abhängigkeiten zu commons-lang3 aufgelöst.
-- `IFS-262`: `isyfact-masterpom` deprecated (Abschaffung mit IsyFact 2.0), `isyfact-masterpom-lib` aufgelöst, Bibliotheken benutzen `isyfact-standards` als Parent-POM
-
-
-# 1.8.0
-- `IFS-189`: Repositories der IsyFact-Standards zusammengeführt, Bibliotheken benutzen wieder gemeinsames Produkt-BOM und werden zentral über das POM isyfact-standards versioniert
-
-# 1.6.0
-- `RF-161`: Bibliotheken binden genutzte Bibliotheken direkt ein und nicht mehr über BOM-Bibliotheken
-
-# 1.5.0
-- `IFS-17`: Umbenennung der Artifact-ID und Group-ID

--- a/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/autoconfigure/IsyMetricsAutoConfiguration.java
+++ b/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/autoconfigure/IsyMetricsAutoConfiguration.java
@@ -44,21 +44,6 @@ public class IsyMetricsAutoConfiguration {
             .description("Liefert die Anzahl der fachlich fehlerhaften Aufrufe.")
             .register(registry);
 
-        Gauge.builder("anzahlAufrufe.LetzteMinute", stats, ServiceStatistik::getAnzahlAufrufeLetzteMinute)
-            .tags(stats.getTags())
-            .description("Liefert die Anzahl aller Aufrufe in der letzten Minute")
-            .register(registry);
-
-        Gauge.builder("anzahlFehler.LetzteMinute", stats, ServiceStatistik::getAnzahlFehlerLetzteMinute)
-            .tags(stats.getTags())
-            .description("Liefert die Anzahl der technisch fehlerhaften Aufrufe in der letzten Minute")
-            .register(registry);
-
-        Gauge.builder("anzahlFachlicheFehler.LetzteMinute", stats, ServiceStatistik::getAnzahlFachlicheFehlerLetzteMinute)
-            .tags(stats.getTags())
-            .description("Liefert die Anzahl der fachlich fehlerhaften Aufrufe in der letzten Minute")
-            .register(registry);
-
         TimeGauge.builder("durchschnittsDauer.LetzteAufrufe", stats, TimeUnit.MILLISECONDS, s -> s.getDurchschnittsDauerLetzteAufrufe().toMillis())
             .tags(stats.getTags())
             .description("Liefert die durchschnittliche Dauer der letzten 10 Aufrufe in ms")

--- a/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/metrics/ServiceStatistik.java
+++ b/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/metrics/ServiceStatistik.java
@@ -35,22 +35,7 @@ public interface ServiceStatistik {
     };
 
     /**
-     * Returns the number of calls counted in the last minute where no error occurred.
-     */
-    int getAnzahlAufrufeLetzteMinute();
-
-    /**
      * Returns the average duration of the last N calls.
      */
     Duration getDurchschnittsDauerLetzteAufrufe();
-
-    /**
-     * Returns the number of calls in the last minute, in which an error occurred.
-     */
-    int getAnzahlFehlerLetzteMinute();
-
-    /**
-     * Returns the number of calls in the last minute, in which a business error occurred.
-     */
-    int getAnzahlFachlicheFehlerLetzteMinute();
 }

--- a/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/metrics/impl/DefaultServiceStatistik.java
+++ b/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/metrics/impl/DefaultServiceStatistik.java
@@ -32,13 +32,6 @@ public class DefaultServiceStatistik implements ServiceStatistik, MethodIntercep
     private static final IsyLogger LOG = IsyLoggerFactory.getLogger(DefaultServiceStatistik.class);
 
     /**
-     * Specifies whether the return object structures should be checked for business errors. May
-     * have an impact on performance.
-     */
-    @Deprecated
-    private boolean businessFehlerpruefung;
-
-    /**
      * Duration of the last search calls (in milliseconds).
      */
     private final ConcurrentLinkedDeque<Duration> letzteSuchdauern = new ConcurrentLinkedDeque<>();
@@ -75,17 +68,6 @@ public class DefaultServiceStatistik implements ServiceStatistik, MethodIntercep
      */
     public DefaultServiceStatistik(String... tags) {
         this.tags = tags.clone();
-    }
-
-    /**
-     * Specifies whether the return object structures should be checked for technical errors. May
-     * have performance implications.
-     *
-     * @param businessFehlerpruefung {@code true} if the return object structure should be checked for technical errors, otherwise {@code false}.
-     */
-    @Deprecated
-    public void setBusinessFehlerpruefung(boolean businessFehlerpruefung) {
-        this.businessFehlerpruefung = businessFehlerpruefung;
     }
 
     @Override
@@ -185,10 +167,6 @@ public class DefaultServiceStatistik implements ServiceStatistik, MethodIntercep
 
     @Override
     public void afterPropertiesSet() {
-        if (businessFehlerpruefung) {
-            LOG.debug("ServiceStatistik mit erweiterter fachlicher Fehlerprüfung initialisiert.");
-        } else {
-            LOG.debug("ServiceStatistik initialisiert.");
-        }
+        LOG.debug("ServiceStatistik initialisiert.");
     }
 }

--- a/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/metrics/impl/DefaultServiceStatistik.java
+++ b/isy-ueberwachung/src/main/java/de/bund/bva/isyfact/ueberwachung/metrics/impl/DefaultServiceStatistik.java
@@ -73,21 +73,9 @@ public class DefaultServiceStatistik implements ServiceStatistik, MethodIntercep
     private final AtomicReference<LocalDateTime> letzteMinute = new AtomicReference<>(DateTimeUtil.localDateTimeNow());
 
     /**
-     * Number of non-error calls made in the minute called 'last minute'.
-     */
-    private final AtomicInteger anzahlAufrufeLetzteMinute = new AtomicInteger();
-
-    /**
      * Number of calls made in the current minute.
      */
     private final AtomicInteger anzahlAufrufeAktuelleMinute = new AtomicInteger();
-
-    /**
-     * The number of technical errors in the last minute.
-     * <p>
-     * A technical error occurs if a {@link TechnicalException} was thrown.
-     */
-    private final AtomicInteger anzahlTechnicalExceptionsLetzteMinute = new AtomicInteger();
 
     /**
      * The number of technical errors in the current minute.
@@ -95,13 +83,6 @@ public class DefaultServiceStatistik implements ServiceStatistik, MethodIntercep
      * A technical error occurs if a {@link TechnicalException} was thrown.
      */
     private final AtomicInteger anzahlTechnicalExceptionsAktuelleMinute = new AtomicInteger();
-
-    /**
-     * The number of business errors in the last minute.
-     * <p>
-     * A business error occurs if a {@link BusinessException} was thrown.
-     */
-    private final AtomicInteger anzahlBusinessExceptionsLetzteMinute = new AtomicInteger();
 
     /**
      * The number of business errors in the current minute.
@@ -191,17 +172,6 @@ public class DefaultServiceStatistik implements ServiceStatistik, MethodIntercep
             LocalDateTime aktuelleMinute = getAktuelleMinute();
             LocalDateTime letzteMinute = this.letzteMinute.get();
             if (!aktuelleMinute.isEqual(letzteMinute)) {
-                if (ChronoUnit.MINUTES.between(letzteMinute, aktuelleMinute) > 1) {
-                    // no last minute infos
-                    anzahlAufrufeLetzteMinute.set(0);
-                    anzahlTechnicalExceptionsLetzteMinute.set(0);
-                    anzahlBusinessExceptionsLetzteMinute.set(0);
-                } else {
-                    anzahlAufrufeLetzteMinute.set(anzahlAufrufeAktuelleMinute.get());
-                    anzahlTechnicalExceptionsLetzteMinute.set(anzahlTechnicalExceptionsAktuelleMinute.get());
-                    anzahlBusinessExceptionsLetzteMinute.set(anzahlBusinessExceptionsAktuelleMinute.get());
-                }
-
                 anzahlAufrufeAktuelleMinute.set(0);
                 anzahlTechnicalExceptionsAktuelleMinute.set(0);
                 anzahlBusinessExceptionsAktuelleMinute.set(0);
@@ -238,24 +208,6 @@ public class DefaultServiceStatistik implements ServiceStatistik, MethodIntercep
     @Override
     public long getAnzahlBusinessExceptions() {
         return anzahlBusinessExceptions.get();
-    }
-
-    @Override
-    public int getAnzahlAufrufeLetzteMinute() {
-        aktualisiereZeitfenster();
-        return anzahlAufrufeLetzteMinute.get();
-    }
-
-    @Override
-    public int getAnzahlFehlerLetzteMinute() {
-        aktualisiereZeitfenster();
-        return anzahlTechnicalExceptionsLetzteMinute.get();
-    }
-
-    @Override
-    public int getAnzahlFachlicheFehlerLetzteMinute() {
-        aktualisiereZeitfenster();
-        return anzahlBusinessExceptionsLetzteMinute.get();
     }
 
     @Override

--- a/isy-ueberwachung/src/test/java/de/bund/bva/isyfact/ueberwachung/metrics/MetricsTest.java
+++ b/isy-ueberwachung/src/test/java/de/bund/bva/isyfact/ueberwachung/metrics/MetricsTest.java
@@ -7,8 +7,6 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalUnit;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
@@ -30,7 +28,6 @@ import de.bund.bva.isyfact.datetime.util.DateTimeUtil;
 import de.bund.bva.isyfact.logging.autoconfigure.IsyLoggingAutoConfiguration;
 import de.bund.bva.isyfact.ueberwachung.metrics.impl.DefaultServiceStatistik;
 
-import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 
@@ -61,9 +58,6 @@ public class MetricsTest {
                         "anzahlAufrufe",
                         "anzahlBusinessExceptions",
                         "anzahlTechnicalExceptions",
-                        "anzahlAufrufe.LetzteMinute",
-                        "anzahlFachlicheFehler.LetzteMinute",
-                        "anzahlFehler.LetzteMinute",
                         "durchschnittsDauer.LetzteAufrufe",
                         "jvm.classes.loaded"
                 )
@@ -90,27 +84,6 @@ public class MetricsTest {
     }
 
     @Test
-    public void serviceStats_lastMinuteAvailable() {
-        testService.call1();
-        testService.call1();
-
-        assertThat(meterRegistry.get("anzahlAufrufe.LetzteMinute").gauges())
-                .extracting(Gauge::value)
-                .containsOnly(0.0);
-
-        moveClockBy(1, ChronoUnit.MINUTES);
-        assertThat(meterRegistry.get("anzahlAufrufe.LetzteMinute").tag("serviceMethod", "call1").gauge().value())
-                .isEqualTo(2.0);
-        assertThat(meterRegistry.get("anzahlAufrufe.LetzteMinute").tag("serviceMethod", "call2").gauge().value())
-                .isZero();
-
-        moveClockBy(2, ChronoUnit.MINUTES);
-        assertThat(meterRegistry.get("anzahlAufrufe.LetzteMinute").gauges())
-                .extracting(Gauge::value)
-                .containsOnly(0.0);
-    }
-
-    @Test
     public void serviceStats_durationStats() {
         final Duration[] durations = { Duration.ofMillis(10), Duration.ofMillis(20), Duration.ofMillis(30) };
 
@@ -128,10 +101,6 @@ public class MetricsTest {
                 .timeGauge()
                 .value(TimeUnit.MILLISECONDS)
         ).isEqualTo(meanDuration.toMillis());
-    }
-
-    private static void moveClockBy(long amountToAdd, TemporalUnit unit) {
-        moveClockBy(Duration.of(amountToAdd, unit));
     }
 
     private static void moveClockBy(Duration amountToAdd) {

--- a/isy-ueberwachung/src/test/java/de/bund/bva/isyfact/ueberwachung/metrics/impl/TestDefaultServiceStatistik.java
+++ b/isy-ueberwachung/src/test/java/de/bund/bva/isyfact/ueberwachung/metrics/impl/TestDefaultServiceStatistik.java
@@ -47,8 +47,6 @@ public class TestDefaultServiceStatistik {
 
     private static final IsyLogger LOG = IsyLoggerFactory.getLogger(TestDefaultServiceStatistik.class);
 
-    private Gauge anzahlAufrufeLetzteMinute;
-    private Gauge anzahlFehlerLetzteMinute;
     private Gauge anzahlAufrufe;
     private Gauge anzahlFehler;
     private Gauge anzahlBusinessFehler;
@@ -56,8 +54,6 @@ public class TestDefaultServiceStatistik {
 
     @PostConstruct
     private void postConstruct() {
-        anzahlAufrufeLetzteMinute = meterRegistry.get("anzahlAufrufe.LetzteMinute").gauge();
-        anzahlFehlerLetzteMinute = meterRegistry.get("anzahlFehler.LetzteMinute").gauge();
         anzahlAufrufe = meterRegistry.get("anzahlAufrufe").gauge();
         anzahlFehler = meterRegistry.get("anzahlTechnicalExceptions").gauge();
         anzahlBusinessFehler = meterRegistry.get("anzahlBusinessExceptions").gauge();
@@ -106,34 +102,21 @@ public class TestDefaultServiceStatistik {
 
         double durchschnittsDauerRef = durchschnittsDauer.value();
 
-        LOG.info(LogKategorie.METRIK, EreignisSchluessel.PLUEB00001,
-            "AnzahlAufrufeLetzteMinute: {}", anzahlAufrufeLetzteMinute.value());
-        LOG.info(LogKategorie.METRIK, EreignisSchluessel.PLUEB00001, "anzahlTechnicalExceptionsLetzteMinute: {}",
-            anzahlFehlerLetzteMinute.value());
         LOG.info(LogKategorie.METRIK, EreignisSchluessel.PLUEB00001, "DurchschnittsDauerLetzteZehnAufrufe: {}",
             durchschnittsDauerRef);
-        // the statistics from the current minute are not yet populated
-        assertEquals(0, anzahlAufrufeLetzteMinute.value(), 0.0);
-        assertEquals(0, anzahlFehlerLetzteMinute.value(), 0.0);
         assertTrue(durchschnittsDauerRef > 0.0);
 
         LOG.debug("Stelle Uhr um 1 Minute nach vorn");
         ((TestClock)DateTimeUtil.getClock()).advanceBy(Duration.ofMinutes(1));
 
-        LOG.info(LogKategorie.METRIK, EreignisSchluessel.PLUEB00001,
-            "AnzahlAufrufeLetzteMinute: {}", anzahlAufrufeLetzteMinute.value());
-        LOG.info(LogKategorie.METRIK, EreignisSchluessel.PLUEB00001, "anzahlTechnicalExceptionsLetzteMinute: {}",
-            anzahlFehlerLetzteMinute.value());
         LOG.info(LogKategorie.METRIK, EreignisSchluessel.PLUEB00001, "DurchschnittsDauerLetzteZehnAufrufe: {}",
             durchschnittsDauerRef);
-        assertEquals(anzahlAufrufe, anzahlAufrufeLetzteMinute.value(), 0.0);
-        assertTrue(anzahlFehlerLetzteMinute.value() > 0.0);
         assertEquals(durchschnittsDauerRef, durchschnittsDauer.value(), 0.0);
         LOG.info(LogKategorie.JOURNAL, EreignisSchluessel.PLUEB00001, "Prüfungen für 1. Minute erfolgreich");
     }
 
     /**
-     * Tests ZaehleAufruf without MBean call in the first minute.
+     * Tests ZaehleAufruf without MBean.
      */
     @Test
     public void testZaehleAufrufNachAbstand() {
@@ -151,30 +134,16 @@ public class TestDefaultServiceStatistik {
 
         double durchschnittsDauerRef = durchschnittsDauer.value();
 
-        LOG.info(LogKategorie.METRIK, EreignisSchluessel.PLUEB00001,
-            "AnzahlAufrufeLetzteMinute: {}", anzahlAufrufeLetzteMinute);
-        LOG.info(LogKategorie.METRIK, EreignisSchluessel.PLUEB00001, "AnzahlTechnicalExceptionsLetzteMinute: {}",
-            anzahlFehlerLetzteMinute);
         LOG.info(LogKategorie.METRIK, EreignisSchluessel.PLUEB00001, "DurchschnittsDauerLetzteZehnAufrufe: {}",
             durchschnittsDauerRef);
-        // the statistics from the current minute are not yet populated
-        assertEquals(0, anzahlAufrufeLetzteMinute.value(), 0.0);
-        assertEquals(0, anzahlFehlerLetzteMinute.value(), 0.0);
         assertTrue(durchschnittsDauerRef > 0.0);
 
-        // wait 120 seconds and check the values. Since there were no calls in the last minute
-        // number of calls and number of erroneous calls should be zero.
+        // wait 120 seconds and check the values
         LOG.debug("Stelle Uhr um 2 Minuten nach vorn");
         ((TestClock)DateTimeUtil.getClock()).advanceBy(Duration.ofMinutes(2));
 
-        LOG.info(LogKategorie.METRIK, EreignisSchluessel.PLUEB00001,
-            "AnzahlAufrufeLetzteMinute: {}", anzahlAufrufeLetzteMinute);
-        LOG.info(LogKategorie.METRIK, EreignisSchluessel.PLUEB00001, "AnzahlTechnicalExceptionsLetzteMinute: {}",
-            anzahlFehlerLetzteMinute);
         LOG.info(LogKategorie.METRIK, EreignisSchluessel.PLUEB00001, "DurchschnittsDauerLetzteZehnAufrufe: {}",
             durchschnittsDauerRef);
-        assertEquals(0, anzahlAufrufeLetzteMinute.value(), 0.0);
-        assertEquals(0, anzahlFehlerLetzteMinute.value(), 0.0);
         assertEquals(durchschnittsDauerRef, durchschnittsDauer.value(), 0.0);
         LOG.info(LogKategorie.JOURNAL, EreignisSchluessel.PLUEB00001, "Prüfungen für 2. Minute erfolgreich");
     }

--- a/isy-ueberwachung/src/test/java/de/bund/bva/isyfact/ueberwachung/metrics/impl/TestDefaultServiceStatistikExceptionHandling.java
+++ b/isy-ueberwachung/src/test/java/de/bund/bva/isyfact/ueberwachung/metrics/impl/TestDefaultServiceStatistikExceptionHandling.java
@@ -4,8 +4,6 @@ import static org.junit.Assert.*;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.lang.reflect.AccessibleObject;
-import java.lang.reflect.Field;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.PostConstruct;
@@ -73,15 +71,13 @@ public class TestDefaultServiceStatistikExceptionHandling {
 
         // Then
         assertNotNull(result);
-        assertEquals(0, getAktuelleBusinessExceptions(serviceStatistik));
-        assertEquals(0, getAktuelleTechnicalExceptions(serviceStatistik));
         assertEquals(0, anzahlBusinessExceptions.value(), 0.01);
         assertEquals(0, anzahlTechnicalExceptions.value(), 0.01);
     }
 
     /**
      * Tests {@link DefaultServiceStatistik#invoke}, to verify that a thrown {@link TechnicalException} is recognized
-     * as a technically unsuccessful call and increments the value of {@code anzahlTechnicalExceptionsAktuelleMinute}.
+     * as a technically unsuccessful call and increments the value of {@code anzahlTechnicalExceptions}.
      */
     @Test(expected = TestTechnicalException.class)
     public void testInvokeWithTechnicalException() throws Throwable {
@@ -92,15 +88,13 @@ public class TestDefaultServiceStatistikExceptionHandling {
         serviceStatistik.invoke(invocation);
 
         // Then
-        assertEquals(1, getAktuelleTechnicalExceptions(serviceStatistik));
-        assertEquals(0, getAktuelleBusinessExceptions(serviceStatistik));
         assertEquals(1, anzahlTechnicalExceptions.value(), 0.01);
         assertEquals(0, anzahlBusinessExceptions.value(), 0.01);
     }
 
     /**
      * Tests {@link DefaultServiceStatistik#invoke}, to verify that a thrown {@link BusinessException} is recognized
-     * as a functionally unsuccessful call and increments the value of {@code anzahlBusinessExceptionsAktuelleMinute}.
+     * as a functionally unsuccessful call and increments the value of {@code anzahlBusinessExceptions}.
      */
     @Test(expected = TestBusinessException.class)
     public void testInvokeWithBusinessException() throws Throwable {
@@ -111,8 +105,6 @@ public class TestDefaultServiceStatistikExceptionHandling {
         serviceStatistik.invoke(invocation);
 
         // Then
-        assertEquals(0, getAktuelleTechnicalExceptions(serviceStatistik));
-        assertEquals(1, getAktuelleBusinessExceptions(serviceStatistik));
         assertEquals(0, anzahlTechnicalExceptions.value(), 0.01);
         assertEquals(1, anzahlBusinessExceptions.value(), 0.01);
     }
@@ -120,7 +112,7 @@ public class TestDefaultServiceStatistikExceptionHandling {
     /**
      * Tests {@link DefaultServiceStatistik#invoke} to verify that a thrown {@link RuntimeException}
      * is recognized as a technically and functionally unsuccessful call and increments
-     * both {@code anzahlTechnicalExceptionsAktuelleMinute} and {@code anzahlBusinessExceptionsAktuelleMinute}.
+     * both {@code anzahlTechnicalExceptions} and {@code anzahlBusinessExceptions}.
      */
     @Test(expected = RuntimeException.class)
     public void testInvokeWithRuntimeException() throws Throwable {
@@ -131,38 +123,8 @@ public class TestDefaultServiceStatistikExceptionHandling {
         serviceStatistik.invoke(invocation);
 
         // Then
-        assertEquals(1, getAktuelleTechnicalExceptions(serviceStatistik));
-        assertEquals(1, getAktuelleBusinessExceptions(serviceStatistik));
         assertEquals(1, anzahlTechnicalExceptions.value(), 0.01);
         assertEquals(1, anzahlBusinessExceptions.value(), 0.01);
-    }
-
-    /**
-     * Helping method to retrieve current count of {@link TechnicalException} reflexively.
-     */
-    private int getAktuelleTechnicalExceptions(DefaultServiceStatistik defaultServiceStatistik) {
-        try {
-            Field field = DefaultServiceStatistik.class.getDeclaredField("anzahlTechnicalExceptionsAktuelleMinute");
-            field.setAccessible(true);
-            AtomicInteger counter = (AtomicInteger) field.get(defaultServiceStatistik);
-            return counter.get();
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new RuntimeException("Error while reflexively reading anzahlTechnicalExceptionsAktuelleMinute", e);
-        }
-    }
-
-    /**
-     * Helping method to retrieve current count of {@link BusinessException} reflexively.
-     */
-    private int getAktuelleBusinessExceptions(DefaultServiceStatistik defaultServiceStatistik) {
-        try {
-            Field field = DefaultServiceStatistik.class.getDeclaredField("anzahlBusinessExceptionsAktuelleMinute");
-            field.setAccessible(true);
-            AtomicInteger counter = (AtomicInteger) field.get(defaultServiceStatistik);
-            return counter.get();
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new RuntimeException("Error while reflexively reading anzahlBusinessExceptionsAktuelleMinute", e);
-        }
     }
 
     /**

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-ueberwachung/pages/nutzungsvorgaben/inhalt.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-ueberwachung/pages/nutzungsvorgaben/inhalt.adoc
@@ -76,11 +76,8 @@ Die dort aufgelisteten Informationen müssen für jeden Service einzeln angebote
 |====
 2+m|Tags: anwendung = <Package der Anwendung>, servicestatistik = <Name des Service>
 m|AnzahlAufrufe |Liefert die Anzahl der erfolgten Aufrufe des Services insgesamt.
-m|AnzahlAufrufeLetzteMinute |Liefert die Anzahl der in der letzten Minute erfolgten Aufrufe des Services.
 m|AnzahlTechnicalExceptions |Liefert die gesamte Anzahl der erfolgten Aufrufe des Services, bei denen ein technischer Fehler aufgetreten ist.
-m|AnzahlTechnicalExceptionsLetzteMinute |Liefert die Anzahl der in der letzten Minute erfolgten Aufrufe des Services, bei denen ein technischer Fehler aufgetreten ist.
 m|AnzahlBusinessExceptions |Liefert die gesamte Anzahl der erfolgten Aufrufe des Services, bei denen ein fachlicher Fehler aufgetreten ist.
-m|AnzahlBusinessExceptionsLetzteMinute |Liefert die Anzahl der in der letzten Minute erfolgten Aufrufe des Services, bei denen ein fachlicher Fehler aufgetreten ist.
 m|DurchschnittsDauerLetzteAufrufe |Liefert die durchschnittliche Bearbeitungsdauer der letzten 10 Aufrufe der Services in Millisekunden (einfacher gleitender Durchschnitt).
 |====
 

--- a/isyfact-standards-doc/src/docs/antora/modules/release/pages/migrationsleitfaden.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/release/pages/migrationsleitfaden.adoc
@@ -12,10 +12,37 @@ Die auf dieser Seite aufgeführten Hinweise sollen der Entwicklung bei der Umste
 [[kapitel-bausteine]]
 == Bausteine
 
+=== isy-persistence
+
+==== Änderungen
 Der Baustein JPA/Hibernate wurde aufgelöst.
+
+==== Auswirkung
 Damit entfällt die Bibliothek `isy-persistence`.
 Hilfsfunktionen zur Definition von Enums und zur Prüfung der Schema-Version wurden in den xref:util::nutzungsvorgaben.adoc[Baustein Util] in die Bibliothek `isy-util` verschoben.
 Alle weitere Funktionalität entfällt und wird durch die direkte Verwendung des Produkts Spring Data ersetzt.
+
+=== isy-ueberwachung
+
+==== Änderungen
+Mit der Version 5.0.0 von `isy-ueberwachung` wurden die folgenden zeitbeschränkten Metriken entfernt:
+
+* `AnzahlAufrufeLetzteMinute`: Anzahl der Anrufe in der letzten Minute
+* `AnzahlTechnicalExceptionsLetzteMinute`: Anzahl der technischen Fehler in der letzten Minute
+* `AnzahlBusinessExceptionsLetzteMinute`: Anzahl der geschäftlichen Fehler in der letzten Minute
+
+Diese Metriken waren zuvor über die `ServiceStatistik`-Schnittstelle verfügbar und wurden automatisch bei Micrometer in der `IsyMetricsAutoConfiguration` registriert.
+
+==== Auswirkung
+Anwendungen, die auf diese Metriken zur Überwachung oder Alarmierung angewiesen sind, müssen ihre Überwachungskonfigurationen anpassen. Die übrigen Metriken ohne Zeitbeschränkung funktionieren weiterhin normal:
+
+* `AnzahlAufrufe`: Gesamtzahl der Anrufe
+* `AnzahlTechnicalExceptions`: Gesamtzahl der technischen Fehler
+* `AnzahlBusinessExceptions`: Gesamtzahl der fachlichen Fehler
+* `DurchschnittsDauerLetzteAufrufe`: Durchschnittsdauer der letzten Anrufe (Defaultwert: 10)
+
+==== Hinweis
+Mithilfe der in Prometheus verfügbaren Funktionen lässt sich die gewohnte Funktionalität nahezu vollständig nachbilden.
 
 [[kapitel-dokumentation]]
 == Dokumentation


### PR DESCRIPTION
* feat: IFS-4791 removes metrics in autoconfiguration
* feat: IFS-4791 removes "*letzteMinute" logic
* feat: IFS-4791 removes "*aktuelleMinute" logic
* feat: IFS-4791 removes deprecated field "businessFehlerpruefung"
* docs: IFS-4791 removes *letzteMinute descriptions
* chore: IFS-4791 adds entry to CHANGELOG.md
* test: IFS-4791 adapts cases
* docs: IFS-4791 adds chapter in migrationsleitfaden.adoc