### PR TITLE
[Sprint 132] IFS-4754 Einführung von Caching im Authentifizierungsprozess 4.1.x

### DIFF
--- a/isy-security/CHANGELOG.md
+++ b/isy-security/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 4.1.0
 
 - `IFS-4591`: Hinzufügen von Authentifizierungsmethoden zur Authentifizierung von Clients und Systemen ohne Issuer-URI.
+- `IFS-4754`: Einführung von Caching im Authentifizierungsprozess
 
 # 4.0.0
 

--- a/isy-security/pom.xml
+++ b/isy-security/pom.xml
@@ -76,6 +76,11 @@
             <artifactId>spring-boot-autoconfigure-processor</artifactId>
             <optional>true</optional>
         </dependency>
+        <!-- for caching logic in isy-security -->
+        <dependency>
+            <groupId>org.ehcache</groupId>
+            <artifactId>ehcache</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>de.bund.bva.isyfact</groupId>

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/autoconfigure/IsyOAuth2ClientAutoConfiguration.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/autoconfigure/IsyOAuth2ClientAutoConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 
 import de.bund.bva.isyfact.security.config.IsyOAuth2ClientConfigurationProperties;
+import de.bund.bva.isyfact.security.config.IsySecurityConfigurationProperties;
 import de.bund.bva.isyfact.security.oauth2.client.Authentifizierungsmanager;
 import de.bund.bva.isyfact.security.oauth2.client.IsyOAuth2Authentifizierungsmanager;
 import de.bund.bva.isyfact.security.oauth2.client.annotation.AuthenticateInterceptor;
@@ -91,8 +92,13 @@ public class IsyOAuth2ClientAutoConfiguration {
     public Authentifizierungsmanager authentifizierungsmanager(
             ProviderManager providerManager,
             IsyOAuth2ClientConfigurationProperties isyOAuth2ClientConfigurationProperties,
+            IsySecurityConfigurationProperties isySecurityConfigurationProperties,
             @Nullable ClientRegistrationRepository clientRegistrationRepository) {
-        return new IsyOAuth2Authentifizierungsmanager(providerManager, isyOAuth2ClientConfigurationProperties, clientRegistrationRepository);
+        return new IsyOAuth2Authentifizierungsmanager(
+                providerManager,
+                isyOAuth2ClientConfigurationProperties,
+                clientRegistrationRepository,
+                isySecurityConfigurationProperties);
     }
 
     /**

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/config/IsySecurityConfigurationProperties.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/config/IsySecurityConfigurationProperties.java
@@ -13,6 +13,11 @@ public class IsySecurityConfigurationProperties {
     /** Path to the XML file containing the role/privilege mappings. */
     private Resource rolePrivilegesMappingFile = new ClassPathResource("/resources/sicherheit/rollenrechte.xml");
 
+    /**
+     * Properties for caching.
+     */
+    private CacheProperties cache = new CacheProperties();
+
     public String getRolesClaimName() {
         return rolesClaimName;
     }
@@ -29,4 +34,44 @@ public class IsySecurityConfigurationProperties {
         this.rolePrivilegesMappingFile = rolePrivilegesMappingFile;
     }
 
+    public CacheProperties getCache() {
+        return cache;
+    }
+
+    public void setCache(CacheProperties cache) {
+        this.cache = cache;
+    }
+
+    /**
+     * Properties for caching.
+     */
+    public static class CacheProperties {
+
+        /**
+         * Time to live in seconds. 0 = caching is disabled.
+         * Configured time to live must be shorter than validity of token.
+         */
+        private int ttl;
+
+        /**
+         * Max number of cached entries.
+         */
+        private int maxelements = 10000;
+
+        public int getTtl() {
+            return ttl;
+        }
+
+        public void setTtl(int ttl) {
+            this.ttl = ttl;
+        }
+
+        public int getMaxelements() {
+            return maxelements;
+        }
+
+        public void setMaxelements(int maxelements) {
+            this.maxelements = maxelements;
+        }
+    }
 }

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/client/Authentifizierungsmanager.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/client/Authentifizierungsmanager.java
@@ -229,4 +229,8 @@ public interface Authentifizierungsmanager {
     void authentifiziereSystem(String issuerLocation, String clientId, String clientSecret, String username, String password, @Nullable String bhknz)
             throws AuthenticationException;
 
+    /**
+     * Clears the cache from isy-security. Authentication data is deleted after the method is called.
+     */
+    void clearCache();
 }

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/client/IsyOAuth2Authentifizierungsmanager.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/client/IsyOAuth2Authentifizierungsmanager.java
@@ -27,6 +27,7 @@ import de.bund.bva.isyfact.security.config.AdditionalCredentials;
 import de.bund.bva.isyfact.security.config.IsyOAuth2ClientConfigurationProperties;
 import de.bund.bva.isyfact.security.config.IsyOAuth2ClientConfigurationProperties.AdditionalRegistrationProperties;
 import de.bund.bva.isyfact.security.config.IsySecurityConfigurationProperties;
+import de.bund.bva.isyfact.security.oauth2.client.authentication.token.AbstractIsyAuthenticationToken;
 import de.bund.bva.isyfact.security.oauth2.client.authentication.token.ClientCredentialsClientRegistrationAuthenticationToken;
 import de.bund.bva.isyfact.security.oauth2.client.authentication.token.ClientCredentialsRegistrationIdAuthenticationToken;
 import de.bund.bva.isyfact.security.oauth2.client.authentication.token.PasswordClientRegistrationAuthenticationToken;
@@ -72,7 +73,7 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
     private final Cache<Integer, Authentication> authenticationCache;
 
     /** Returns whether the cache is enabled or not. */
-    private boolean cacheEnabled;
+    private final boolean cacheEnabled;
 
     /** The alias for the cache. */
     private static final String CACHE_ALIAS = "de.bund.bva.isyfact.security.oauth2.authentifizierung";
@@ -196,7 +197,7 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
      * Called by Spring when application context is being shut down.
      */
     @Override
-    public void destroy() throws Exception {
+    public void destroy() {
         if (cacheManager != null) {
             cacheManager.close();
         }
@@ -337,10 +338,10 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
 
     /**
      * Initializes the authentication cache based on configured properties.
-     * If time to live (TTL) equals 0, caching is disabled and null values is returned.
+     * If time to live (TTL) equals 0, caching is disabled and null-values are returned.
      *
      * @param properties security configuration properties containing cache settings
-     * @return CacheSetupResult containing both cacheManager and cache (both can be null if caching disabled)
+     * @return CacheSetupResult containing both cacheManager and cache or null if caching is disabled
      */
     private CacheSetupResult setupCache(IsySecurityConfigurationProperties properties) {
         if (properties.getCache().getTtl() == 0) {
@@ -380,30 +381,33 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
     private void authenticateAndChangeAuthenticatedPrincipal(Authentication unauthenticatedToken) throws AuthenticationException {
         Authentication authentication;
 
-        // No caching of ClientCredentialsRegistrationIdAuthenticationToken
-        // because it is cached by Spring's OAuth2AuthorizedClientManager
-        if (unauthenticatedToken instanceof ClientCredentialsRegistrationIdAuthenticationToken) {
-            authentication = performAuthentication(unauthenticatedToken);
-        } else if (cacheEnabled) {
+        if (cacheEnabled) {
             authentication = authenticateWithCache(unauthenticatedToken);
         } else {
             authentication = performAuthentication(unauthenticatedToken);
         }
-
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
     /**
      * Performs authentication with prior check of the cache for existing successful authentication data.
-     * If cached authentication exists, it returns the cached value.
-     * Otherwise, it performs authentication and caches the result if successful.
+     * If cached authentication exists and matches the incoming authentication, it returns the cached value.
+     * Otherwise, it performs a new authentication and caches the result if successful.
      *
      * @param unauthenticatedToken the authentication token to process
      */
     private Authentication authenticateWithCache(Authentication unauthenticatedToken) throws AuthenticationException {
-        Integer cacheKey = generateCacheKey(unauthenticatedToken);
-        Authentication cachedAuthentication = authenticationCache.get(cacheKey);
+        AbstractIsyAuthenticationToken isyAuthenticationToken = (AbstractIsyAuthenticationToken) unauthenticatedToken;
+        // ClientCredentialsRegistrationIdAuthenticationToken will return null-value for cacheKey
+        // and so it will not be cached by the logic of Isy-Security
+        // because it is cached by Spring's OAuth2AuthorizedClientManager
+        Integer cacheKey = isyAuthenticationToken.generateCacheKey();
 
+        if (cacheKey == null) {
+            return performAuthentication(unauthenticatedToken);
+        }
+
+        Authentication cachedAuthentication = authenticationCache.get(cacheKey);
         if (cachedAuthentication != null) {
             return cachedAuthentication;
         }
@@ -426,28 +430,30 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
     }
 
     /**
-     * Generates a cache key from the authentication token.
-     * The key is used to check whether authentication has already been performed.
-     * If so, the cached {@link Authentication} result is used and the authentication
-     * providers are not called again.
-     *
-     * @param token the authentication token to generate a key for
-     * @return the generated cache key as hash code
-     */
-    private Integer generateCacheKey(Authentication token) {
-        return token.toString().hashCode();
-    }
-
-    /**
-     * Helper class to return both cache and cacheManager from setupCache method
+     * Helper class to return both cache and cacheManager from setupCache method.
      */
     private static class CacheSetupResult {
-        final CacheManager cacheManager;
-        final Cache<Integer, Authentication> cache;
+        /**
+         * The Cache Manager.
+         */
+        private final CacheManager cacheManager;
+
+        /**
+         * The Cache.
+         */
+        private final Cache<Integer, Authentication> cache;
 
         CacheSetupResult(CacheManager cacheManager, Cache<Integer, Authentication> cache) {
             this.cacheManager = cacheManager;
             this.cache = cache;
+        }
+
+        public CacheManager getCacheManager() {
+            return cacheManager;
+        }
+
+        public Cache<Integer, Authentication> getCache() {
+            return cache;
         }
     }
 }

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/client/IsyOAuth2Authentifizierungsmanager.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/client/IsyOAuth2Authentifizierungsmanager.java
@@ -359,14 +359,14 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
                                         Duration.ofSeconds(properties.getCache().getTtl())))
                         .build();
 
-        CacheManager cacheManager =
+        CacheManager configuredCacheManager =
                 CacheManagerBuilder.newCacheManagerBuilder()
                         .withCache(CACHE_ALIAS, cacheConfiguration)
                         .build(true);
 
-        Cache<Integer, Authentication> cache = cacheManager.getCache(CACHE_ALIAS, Integer.class, Authentication.class);
+        Cache<Integer, Authentication> cache = configuredCacheManager.getCache(CACHE_ALIAS, Integer.class, Authentication.class);
 
-        return new CacheSetupResult(cacheManager, cache);
+        return new CacheSetupResult(configuredCacheManager, cache);
     }
 
     /**

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/client/IsyOAuth2Authentifizierungsmanager.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/client/IsyOAuth2Authentifizierungsmanager.java
@@ -9,6 +9,7 @@ import org.ehcache.config.builders.CacheConfigurationBuilder;
 import org.ehcache.config.builders.CacheManagerBuilder;
 import org.ehcache.config.builders.ExpiryPolicyBuilder;
 import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.lang.Nullable;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -48,7 +49,7 @@ import de.bund.bva.isyfact.security.oauth2.util.IsySecurityTokenUtil;
  * Client Registration with the provided credentials and issuer location and thus do not depend on any to be
  * configured in the application properties. Note that these are marked {@link Deprecated}.
  */
-public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsmanager {
+public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsmanager, DisposableBean {
 
     /**
      * ProviderManager configured with supported {@link AuthenticationProvider}s.
@@ -58,6 +59,11 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
      * @see IsyOAuth2Authentifizierungsmanager more details in the class doc
      */
     private final ProviderManager providerManager;
+
+    /**
+     * Used to build a cache.
+     */
+    private final CacheManager cacheManager;
 
     /**
      * Cache used to provide authentication data for repeated requests.
@@ -90,7 +96,9 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
         this.isyOAuth2ClientProps = isyOAuth2ClientProps;
         this.clientRegistrationRepository = clientRegistrationRepository;
 
-        this.authenticationCache = setupCache(isySecurityConfigurationProps);
+        CacheSetupResult cacheSetupResult = setupCache(isySecurityConfigurationProps);
+        this.cacheManager = cacheSetupResult.cacheManager;
+        this.authenticationCache = cacheSetupResult.cache;
         this.cacheEnabled = isySecurityConfigurationProps.getCache().getTtl() > 0;
     }
 
@@ -172,6 +180,26 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
 
         Authentication unauthenticatedToken = new PasswordClientRegistrationAuthenticationToken(clientRegistration, username, password, bhknz);
         authenticateAndChangeAuthenticatedPrincipal(unauthenticatedToken);
+    }
+
+    /**
+     * Clears the cache when cache is enabled and not null.
+     */
+    public void clearCache() {
+        if (cacheEnabled && authenticationCache != null) {
+            authenticationCache.clear();
+        }
+    }
+
+    /**
+     * Closes the cache manager when the bean is destroyed.
+     * Called by Spring when application context is being shut down.
+     */
+    @Override
+    public void destroy() throws Exception {
+        if (cacheManager != null) {
+            cacheManager.close();
+        }
     }
 
     /**
@@ -309,15 +337,14 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
 
     /**
      * Initializes the authentication cache based on configured properties.
-     * If time to live (TTL) equals 0, caching is disabled and null is returned.
+     * If time to live (TTL) equals 0, caching is disabled and null values is returned.
      *
      * @param properties security configuration properties containing cache settings
-     * @return the configured cache or null if caching is disabled
+     * @return CacheSetupResult containing both cacheManager and cache (both can be null if caching disabled)
      */
-    private Cache<Integer, Authentication> setupCache(IsySecurityConfigurationProperties properties) {
+    private CacheSetupResult setupCache(IsySecurityConfigurationProperties properties) {
         if (properties.getCache().getTtl() == 0) {
-            cacheEnabled = false;
-            return null;
+            return new CacheSetupResult(null, null);
         }
 
         CacheConfiguration<Integer, Authentication> cacheConfiguration =
@@ -336,7 +363,9 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
                         .withCache(CACHE_ALIAS, cacheConfiguration)
                         .build(true);
 
-        return cacheManager.getCache(CACHE_ALIAS, Integer.class, Authentication.class);
+        Cache<Integer, Authentication> cache = cacheManager.getCache(CACHE_ALIAS, Integer.class, Authentication.class);
+
+        return new CacheSetupResult(cacheManager, cache);
     }
 
     /**
@@ -410,11 +439,15 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
     }
 
     /**
-     * Clears the cache when cache is enabled and not null.
+     * Helper class to return both cache and cacheManager from setupCache method
      */
-    public void clearCache() {
-        if (cacheEnabled && authenticationCache != null) {
-            authenticationCache.clear();
+    private static class CacheSetupResult {
+        final CacheManager cacheManager;
+        final Cache<Integer, Authentication> cache;
+
+        CacheSetupResult(CacheManager cacheManager, Cache<Integer, Authentication> cache) {
+            this.cacheManager = cacheManager;
+            this.cache = cache;
         }
     }
 }

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/client/IsyOAuth2Authentifizierungsmanager.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/client/IsyOAuth2Authentifizierungsmanager.java
@@ -2,6 +2,13 @@ package de.bund.bva.isyfact.security.oauth2.client;
 
 import java.time.Duration;
 
+import org.ehcache.Cache;
+import org.ehcache.CacheManager;
+import org.ehcache.config.CacheConfiguration;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.CacheManagerBuilder;
+import org.ehcache.config.builders.ExpiryPolicyBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
 import org.springframework.lang.Nullable;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -18,6 +25,7 @@ import org.springframework.util.Assert;
 import de.bund.bva.isyfact.security.config.AdditionalCredentials;
 import de.bund.bva.isyfact.security.config.IsyOAuth2ClientConfigurationProperties;
 import de.bund.bva.isyfact.security.config.IsyOAuth2ClientConfigurationProperties.AdditionalRegistrationProperties;
+import de.bund.bva.isyfact.security.config.IsySecurityConfigurationProperties;
 import de.bund.bva.isyfact.security.oauth2.client.authentication.token.ClientCredentialsClientRegistrationAuthenticationToken;
 import de.bund.bva.isyfact.security.oauth2.client.authentication.token.ClientCredentialsRegistrationIdAuthenticationToken;
 import de.bund.bva.isyfact.security.oauth2.client.authentication.token.PasswordClientRegistrationAuthenticationToken;
@@ -51,6 +59,19 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
      */
     private final ProviderManager providerManager;
 
+    /**
+     * Cache used to provide authentication data for repeated requests.
+     * Can be configured via properties 'ttl' and 'maxelements'.
+     */
+    private final Cache<Integer, Authentication> authenticationCache;
+
+    /** Returns whether the cache is enabled or not. */
+    private boolean cacheEnabled;
+
+    /** The alias for the cache. */
+    private static final String CACHE_ALIAS = "de.bund.bva.isyfact.security.oauth2.authentifizierung";
+
+
     /** Global isy-security Configuration properties. */
     private final IsyOAuth2ClientConfigurationProperties isyOAuth2ClientProps;
 
@@ -63,10 +84,14 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
 
     public IsyOAuth2Authentifizierungsmanager(ProviderManager providerManager,
                                               IsyOAuth2ClientConfigurationProperties isyOAuth2ClientProps,
-                                              @Nullable ClientRegistrationRepository clientRegistrationRepository) {
+                                              @Nullable ClientRegistrationRepository clientRegistrationRepository,
+                                              IsySecurityConfigurationProperties isySecurityConfigurationProps) {
         this.providerManager = providerManager;
         this.isyOAuth2ClientProps = isyOAuth2ClientProps;
         this.clientRegistrationRepository = clientRegistrationRepository;
+
+        this.authenticationCache = setupCache(isySecurityConfigurationProps);
+        this.cacheEnabled = isySecurityConfigurationProps.getCache().getTtl() > 0;
     }
 
     @Override
@@ -283,6 +308,38 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
     }
 
     /**
+     * Initializes the authentication cache based on configured properties.
+     * If time to live (TTL) equals 0, caching is disabled and null is returned.
+     *
+     * @param properties security configuration properties containing cache settings
+     * @return the configured cache or null if caching is disabled
+     */
+    private Cache<Integer, Authentication> setupCache(IsySecurityConfigurationProperties properties) {
+        if (properties.getCache().getTtl() == 0) {
+            cacheEnabled = false;
+            return null;
+        }
+
+        CacheConfiguration<Integer, Authentication> cacheConfiguration =
+                CacheConfigurationBuilder
+                        .newCacheConfigurationBuilder(
+                                Integer.class,
+                                Authentication.class,
+                                ResourcePoolsBuilder.heap(properties.getCache().getMaxelements()))
+                        .withExpiry(
+                                ExpiryPolicyBuilder.timeToLiveExpiration(
+                                        Duration.ofSeconds(properties.getCache().getTtl())))
+                        .build();
+
+        CacheManager cacheManager =
+                CacheManagerBuilder.newCacheManagerBuilder()
+                        .withCache(CACHE_ALIAS, cacheConfiguration)
+                        .build(true);
+
+        return cacheManager.getCache(CACHE_ALIAS, Integer.class, Authentication.class);
+    }
+
+    /**
      * Tries to authorize the given request with one of the providers configured in the {@link #providerManager} and update
      * the authenticated principal.
      *
@@ -292,8 +349,72 @@ public class IsyOAuth2Authentifizierungsmanager implements Authentifizierungsman
      *         if no provider supports the authentication request or the authentication failed
      */
     private void authenticateAndChangeAuthenticatedPrincipal(Authentication unauthenticatedToken) throws AuthenticationException {
-        Authentication authentication = providerManager.authenticate(unauthenticatedToken);
+        Authentication authentication;
+
+        // No caching of ClientCredentialsRegistrationIdAuthenticationToken
+        // because it is cached by Spring's OAuth2AuthorizedClientManager
+        if (unauthenticatedToken instanceof ClientCredentialsRegistrationIdAuthenticationToken) {
+            authentication = performAuthentication(unauthenticatedToken);
+        } else if (cacheEnabled) {
+            authentication = authenticateWithCache(unauthenticatedToken);
+        } else {
+            authentication = performAuthentication(unauthenticatedToken);
+        }
+
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
+    /**
+     * Performs authentication with prior check of the cache for existing successful authentication data.
+     * If cached authentication exists, it returns the cached value.
+     * Otherwise, it performs authentication and caches the result if successful.
+     *
+     * @param unauthenticatedToken the authentication token to process
+     */
+    private Authentication authenticateWithCache(Authentication unauthenticatedToken) throws AuthenticationException {
+        Integer cacheKey = generateCacheKey(unauthenticatedToken);
+        Authentication cachedAuthentication = authenticationCache.get(cacheKey);
+
+        if (cachedAuthentication != null) {
+            return cachedAuthentication;
+        }
+
+        Authentication authentication = performAuthentication(unauthenticatedToken);
+        if (authentication != null && authentication.isAuthenticated()) {
+            authenticationCache.put(cacheKey, authentication);
+        }
+
+        return authentication;
+    }
+
+    /**
+     * Performs the actual authentication process by delegating to the provider manager.
+     *
+     * @param unauthenticatedToken the authentication token to authenticate
+     */
+    private Authentication performAuthentication(Authentication unauthenticatedToken) {
+        return providerManager.authenticate(unauthenticatedToken);
+    }
+
+    /**
+     * Generates a cache key from the authentication token.
+     * The key is used to check whether authentication has already been performed.
+     * If so, the cached {@link Authentication} result is used and the authentication
+     * providers are not called again.
+     *
+     * @param token the authentication token to generate a key for
+     * @return the generated cache key as hash code
+     */
+    private Integer generateCacheKey(Authentication token) {
+        return token.toString().hashCode();
+    }
+
+    /**
+     * Clears the cache when cache is enabled and not null.
+     */
+    public void clearCache() {
+        if (cacheEnabled && authenticationCache != null) {
+            authenticationCache.clear();
+        }
+    }
 }

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/AbstractClientRegistrationAuthenticationToken.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/AbstractClientRegistrationAuthenticationToken.java
@@ -1,5 +1,7 @@
 package de.bund.bva.isyfact.security.oauth2.client.authentication.token;
 
+import java.util.Objects;
+
 import org.springframework.lang.Nullable;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 
@@ -19,5 +21,30 @@ public abstract class AbstractClientRegistrationAuthenticationToken extends Abst
 
     public ClientRegistration getClientRegistration() {
         return clientRegistration;
+    }
+
+    /**
+     * Generates a cache key that includes the following fields.
+     * <ul>
+     *     <li>principal</li>
+     *     <li>bhknz</li>
+     *     <li>issuerLocation</li>
+     *     <li>clientId</li>
+     *     <li>clientSecret</li>
+     *     <li>authorizationGrantType</li>
+     * </ul>
+     *
+     * @return the generated cache key as hash code or null
+     */
+    @Override
+    public Integer generateCacheKey() {
+        return Objects.hash(
+                getPrincipal(),
+                getBhknz(),
+                getClientRegistration().getProviderDetails().getIssuerUri(),
+                getClientRegistration().getClientId(),
+                getClientRegistration().getClientSecret(),
+                getClientRegistration().getAuthorizationGrantType()
+        );
     }
 }

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/AbstractIsyAuthenticationToken.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/AbstractIsyAuthenticationToken.java
@@ -49,4 +49,7 @@ public abstract class AbstractIsyAuthenticationToken extends AbstractAuthenticat
     public String getBhknz() {
         return bhknz;
     }
+
+    @Nullable
+    public abstract Integer generateCacheKey();
 }

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/ClientCredentialsRegistrationIdAuthenticationToken.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/ClientCredentialsRegistrationIdAuthenticationToken.java
@@ -19,4 +19,14 @@ public class ClientCredentialsRegistrationIdAuthenticationToken extends Abstract
     public String getRegistrationId() {
         return registrationId;
     }
+
+    /**
+     * Generates a null value for the cache key.
+     *
+     * @return null
+     */
+    @Override
+    public Integer generateCacheKey() {
+        return null;
+    }
 }

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/PasswordClientRegistrationAuthenticationToken.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/oauth2/client/authentication/token/PasswordClientRegistrationAuthenticationToken.java
@@ -1,5 +1,7 @@
 package de.bund.bva.isyfact.security.oauth2.client.authentication.token;
 
+import java.util.Objects;
+
 import org.springframework.lang.Nullable;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 
@@ -27,5 +29,25 @@ public class PasswordClientRegistrationAuthenticationToken extends AbstractClien
 
     public String getPassword() {
         return password;
+    }
+
+    /**
+     * Generates a cache key that includes the following fields.
+     * <ul>
+     *     <li>principal</li>
+     *     <li>bhknz</li>
+     *     <li>issuerLocation</li>
+     *     <li>clientId</li>
+     *     <li>clientSecret</li>
+     *     <li>authorizationGrantType</li>
+     *     <li>username</li>
+     *     <li>password</li>
+     * </ul>
+     *
+     * @return the generated cache key as hash code or null
+     */
+    @Override
+    public Integer generateCacheKey() {
+        return Objects.hash(super.generateCacheKey(), getUsername(), getPassword());
     }
 }

--- a/isy-security/src/test/java/de/bund/bva/isyfact/security/oauth2/client/AuthentifizierungsmanagerTest.java
+++ b/isy-security/src/test/java/de/bund/bva/isyfact/security/oauth2/client/AuthentifizierungsmanagerTest.java
@@ -75,7 +75,7 @@ public class AuthentifizierungsmanagerTest extends AbstractOidcProviderTest {
         SecurityContextHolder.getContext().setAuthentication(null);
 
         mockJwt = mock(JwtAuthenticationToken.class);
-        JwtAuthenticationToken secondMockJwt = mock(JwtAuthenticationToken.class);;
+        JwtAuthenticationToken secondMockJwt = mock(JwtAuthenticationToken.class);
 
         when(clientCredentialsAuthorizedClientAuthenticationProvider.supports(any())).thenCallRealMethod();
         when(clientCredentialsAuthorizedClientAuthenticationProvider.authenticate(any(Authentication.class))).thenReturn(mockJwt);

--- a/isy-security/src/test/java/de/bund/bva/isyfact/security/oauth2/client/AuthentifizierungsmanagerWithDisabledCacheTest.java
+++ b/isy-security/src/test/java/de/bund/bva/isyfact/security/oauth2/client/AuthentifizierungsmanagerWithDisabledCacheTest.java
@@ -1,0 +1,56 @@
+package de.bund.bva.isyfact.security.oauth2.client;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.test.context.TestPropertySource;
+
+import de.bund.bva.isyfact.security.AbstractOidcProviderTest;
+import de.bund.bva.isyfact.security.oauth2.client.authentication.ClientCredentialsClientRegistrationAuthenticationProvider;
+
+/**
+ * Tests the Authentifizierungsmanager with disabled caching.
+ */
+@SpringBootTest
+@TestPropertySource(properties = {
+        "isy.security.cache.ttl=0"
+})
+public class AuthentifizierungsmanagerWithDisabledCacheTest extends AbstractOidcProviderTest {
+
+    @MockBean
+    private ClientCredentialsClientRegistrationAuthenticationProvider clientCredentialsProvider;
+
+    @Autowired
+    private Authentifizierungsmanager authentifizierungsmanager;
+
+    @BeforeEach
+    public void setup() {
+        SecurityContextHolder.clearContext();
+        JwtAuthenticationToken mockJwt = mock(JwtAuthenticationToken.class);
+
+        when(clientCredentialsProvider.supports(any())).thenCallRealMethod();
+        when(clientCredentialsProvider.authenticate(any(Authentication.class))).thenReturn(mockJwt);
+    }
+
+    @Test
+    public void testNoCachingWhenDisabled() {
+
+        authentifizierungsmanager.authentifiziereClient(getIssuer(), "testid", "testsecret");
+        verify(clientCredentialsProvider, times(1)).authenticate(any());
+        SecurityContextHolder.clearContext();
+
+        authentifizierungsmanager.authentifiziereClient(getIssuer(), "testid", "testsecret");
+        verify(clientCredentialsProvider, times(2)).authenticate(any());
+    }
+}

--- a/isy-security/src/test/java/de/bund/bva/isyfact/security/oauth2/client/AuthentifizierungsmanagerWithLimitedCacheTest.java
+++ b/isy-security/src/test/java/de/bund/bva/isyfact/security/oauth2/client/AuthentifizierungsmanagerWithLimitedCacheTest.java
@@ -1,0 +1,98 @@
+package de.bund.bva.isyfact.security.oauth2.client;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.test.context.TestPropertySource;
+
+import de.bund.bva.isyfact.security.AbstractOidcProviderTest;
+import de.bund.bva.isyfact.security.oauth2.client.authentication.PasswordClientRegistrationAuthenticationProvider;
+
+/**
+ * Tests the caching of the Authentifizierungsmanager with more authentication attempts than max. cached elements.
+ */
+@SpringBootTest
+@TestPropertySource(properties = {
+        "isy.security.cache.ttl=300",
+        "isy.security.cache.maxelements=2"
+})
+public class AuthentifizierungsmanagerWithLimitedCacheTest extends AbstractOidcProviderTest {
+
+    @MockBean
+    private PasswordClientRegistrationAuthenticationProvider passwordClientRegistrationAuthenticationProvider;
+
+    @Autowired
+    private Authentifizierungsmanager authentifizierungsmanager;
+
+    private JwtAuthenticationToken mockJwt;
+
+    @BeforeEach
+    public void configureMocks() {
+        // clear authenticated principal
+        SecurityContextHolder.getContext().setAuthentication(null);
+        mockJwt = mock(JwtAuthenticationToken.class);
+
+        when(passwordClientRegistrationAuthenticationProvider.supports(any())).thenCallRealMethod();
+        when(passwordClientRegistrationAuthenticationProvider.authenticate(any(Authentication.class))).thenReturn(mockJwt);
+
+    }
+
+    @Test
+    public void testCacheWithMoreAuthenticationAttemptsThanCachedElements() {
+
+        // Override value from @BeforeEach otherwise the authentication.isAuthenticated returns always false
+        when(mockJwt.isAuthenticated()).thenReturn(true);
+
+        // First authentication attempt with credentials from testid1
+        // Provider is called
+        authentifizierungsmanager.authentifiziereSystem(getIssuer(), "testid1", "testsecret1", "testuser1", "testpw1");
+        verify(passwordClientRegistrationAuthenticationProvider, times(1)).authenticate(any());
+        SecurityContextHolder.clearContext();
+        clearInvocations(passwordClientRegistrationAuthenticationProvider);
+
+        // Second authentication attempt with credentials from testid1
+        // provider is not called, authentication data is taken from cache
+        authentifizierungsmanager.authentifiziereSystem(getIssuer(), "testid1", "testsecret1", "testuser1", "testpw1");
+        verify(passwordClientRegistrationAuthenticationProvider, never()).authenticate(any());
+        SecurityContextHolder.clearContext();
+
+        // First authentication attempt with credentials from testid2
+        // Provider is called
+        authentifizierungsmanager.authentifiziereSystem(getIssuer(), "testid2", "testsecret2", "testuser2", "testpw2");
+        verify(passwordClientRegistrationAuthenticationProvider, times(1)).authenticate(any());
+        SecurityContextHolder.clearContext();
+        clearInvocations(passwordClientRegistrationAuthenticationProvider);
+
+        // Second authentication attempt with credentials from testid2
+        // provider is not called, authentication data is taken from cache
+        authentifizierungsmanager.authentifiziereSystem(getIssuer(), "testid2", "testsecret2", "testuser2", "testpw2");
+        verify(passwordClientRegistrationAuthenticationProvider, never()).authenticate(any());
+        SecurityContextHolder.clearContext();
+
+        // First authentication attempt with credentials from testid3
+        // Provider is called
+        authentifizierungsmanager.authentifiziereSystem(getIssuer(), "testid3", "testsecret3", "testuser3", "testpw3");
+        verify(passwordClientRegistrationAuthenticationProvider, times(1)).authenticate(any());
+        SecurityContextHolder.clearContext();
+        clearInvocations(passwordClientRegistrationAuthenticationProvider);
+
+        // Now third authentication attempt with credentials from testid1
+        // Provider is called because there is no more cached data for testid1 due to the maxelements specification
+        authentifizierungsmanager.authentifiziereSystem(getIssuer(), "testid1", "testsecret1", "testuser1", "testpw1");
+        verify(passwordClientRegistrationAuthenticationProvider, times(1)).authenticate(any());
+        SecurityContextHolder.clearContext();
+    }
+}

--- a/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/inhalt.adoc
+++ b/isyfact-standards-doc/src/docs/antora/modules/isy-security/pages/nutzungsvorgaben/inhalt.adoc
@@ -355,6 +355,33 @@ public class OAuth2WebClientConfiguration {
 }
 ----
 
+[[authentication-caching]]
+=== Caching von Authentifizierungen
+
+Der Authentifizierungsmanager bietet eine integrierte Caching-Funktionalität zur Performance-Optimierung bei wiederholten Authentifizierungsanfragen.
+
+[[funktionweise]]
+==== Funktionsweise
+
+Erfolgreiche Authentifizierungsergebnisse werden zwischengespeichert, um identische Anfragen innerhalb eines konfigurierbaren Zeitfensters ohne erneuten IAM-Service-Aufruf zu bedienen.
+
+NOTE: `ClientCredentialsRegistrationIdAuthenticationToken` wird nicht gecacht, da Spring Security bereits eigenes Caching über den `OAuth2AuthorizedClientManager` bereitstellt.
+
+[[table-cache-configuration]]
+.Konfigurationsparameter für Authentifizierungscache
+[cols="3m,1m,5",options="header"]
+|===
+|Parameter |Default |Beschreibung
+|isy.security.cache.ttl |0 |Time-to-Live in Sekunden. `0` = Cache ist deaktiviert.
+|isy.security.cache.maxelements |10000 |Maximale Anzahl von gecachten Einträgen.
+|===
+
+WARNING: Die Cache-TTL muss kürzer als die Token-Gültigkeitsdauer konfiguriert werden, um die Verwendung abgelaufener Authentifizierungen zu verhindern.
+
+Zum Löschen des Cache steht die folgende Methode zur Verfügung:
+
+`void clearCache()`:: Leert den gesamten Authentifizierungscache.
+
 [[auth_sgw]]
 == Authentifizierung über das SGW am IAM-Service
 Die Authentifizierung über das Service Gateway (SGW) stellt einen wichtigen Schritt in der Sicherung von Anwendungen dar.


### PR DESCRIPTION
* build: IFS-4754: add dependency for ehCache
* feat: IFS-4754: add caching-properties in IsySecurityConfigurationProperties
* feat: IFS-4754: add logic for caching in authentication process
* feat: IFS-4754: add new method to Authentifizierungsmanager and supplement called Authentifizierungsmanager constructor signature
*  test: IFS-4754: add tests for new logic
* feat: IFS-4754: implement DisposableBean in IsyOAuth2Authentifizierungsmanager to enable destroy()-Method for closing CacheManager after shutdown of bean
* docs: IFS-4754: add documentation for caching logic
* chore: IFS-4754: update changelogs
* feat: IFS-4754: add method generateCacheKey() in AbstractIsyAuthenticationToken and its inheritors
* feat: IFS-4754: rewrite logic of generating cacheKey and checking for type of auth token
* test: IFS-4754: add test for testing slightly different input data for authentication