### PR TITLE
[Sprint 132] IFS-4527 enable documentation build

### DIFF
--- a/isyfact-standards-doc/pom.xml
+++ b/isyfact-standards-doc/pom.xml
@@ -36,7 +36,6 @@
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctor-maven-plugin</artifactId>
                         <version>${asciidoctor.maven.plugin.version}</version>
-
                         <configuration>
                             <outputDirectory>${project.build.directory}</outputDirectory>
                             <attributes>


### PR DESCRIPTION
style: IFS-4527 tidy isyfact-standards-doc pom.xml
* otherwise the documentation build fails