### PR TITLE
[Sprint 132] IFS-4527 Release 3.3.0 - fix documentation build for master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 - `IFS-4208`: [isyfact-standards-doc] Verwendungen der Begriffe "Nachbarsystem" und "Externes System" korrigiert
 - `IFS-4731`: Korrektes Auflösen der URL in SBOMs
 - `IFS-4530`: Update von UCP auf Version 19.27.0.0
-- `IFS-4532`: [isyfact-standards-doc] Entfernt die Maven Property org.asciidoctorj.pdf aus Dokumentationsbuild
 - `IFS-4655`: Update von Maven Checkstyle Plugin auf Version 3.6.0
 
 ## BREAKING CHANGES

--- a/isyfact-standards-doc/pom.xml
+++ b/isyfact-standards-doc/pom.xml
@@ -12,6 +12,7 @@
         <pfad.methodik>src/docs/antora/modules/methodik</pfad.methodik>
 
         <asciidoctor.maven.plugin.version>2.2.6</asciidoctor.maven.plugin.version>
+        <asciidoctorj.pdf.version>2.3.10</asciidoctorj.pdf.version>
     </properties>
 
     <profiles>
@@ -36,6 +37,14 @@
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctor-maven-plugin</artifactId>
                         <version>${asciidoctor.maven.plugin.version}</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.asciidoctor</groupId>
+                                <artifactId>asciidoctorj-pdf</artifactId>
+                                <version>${asciidoctorj.pdf.version}</version>
+                            </dependency>
+                        </dependencies>
+
                         <configuration>
                             <outputDirectory>${project.build.directory}</outputDirectory>
                             <attributes>


### PR DESCRIPTION
build: IFS-4527 add asciidoctorj pdf property and dependency as they are required for the build of isyfact-standards-doc

This reverts IFS-4532