### PR TITLE
[Sprint 135] IFS-4817 add securityMatcher bugfix to CHANGELOG.md (IF4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,5 +25,7 @@
 ## BUG FIXES
 - `IFS-4526`: [isy-task] Logeintrag IsyTaskAspect korrigiert
 - `IFS-4495`: [isy-task] Verwendung der Defaults, falls keine Task-Config definiert ist
+- `IFS-4817`: [isy-ueberwachung] Verwendung von `securityMatcher` in actuatorSecurityFilterChain und loadbalancerSecurityFilterChain für korrektes Filtern von Anfragen.
 
 ## BREAKING CHANGES
+- keine

--- a/isy-ueberwachung/CHANGELOG.md
+++ b/isy-ueberwachung/CHANGELOG.md
@@ -1,4 +1,7 @@
 # 4.1.0
+## FEATURES
 - `IFS-4534`: Bereitstellen von Metriken ohne Zeiteinschränkungen
 - `IFS-4715`: Öffnung des Health-Endpunkts ohne Autorisierung
 - `IFS-4791`: ServiceStatistik: Deprecation von Metriken mit Zeiteinschränkungen
+## BUG FIXES
+- `IFS-4817`: Verwendung von `securityMatcher` in actuatorSecurityFilterChain und loadbalancerSecurityFilterChain für korrektes Filtern von Anfragen.


### PR DESCRIPTION
* docs: IFS-4817 update CHANGELOG.md
  * add entry for Changes of IFS-3630