### PR TITLE
[Sprint 138] ifs 4748 4.x entfernung veralteter spring boot api nutzung

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
     * Update von com.github.spotbugs:spotbugs-maven-plugin von 4.8.6.6 auf 4.9.3.2
     * Update von commons-beanutils:commons-beanutils von 1.9.4 auf 1.11.0
     * Update von org.springframework.boot:spring-boot-dependencies von 3.5.3 auf 3.5.4
+- `IFS-4748`: [isy-batchrahmen], [isy-security] Alle deprecated Spring-Boot-Funktionen auf aktuelle Alternativen umgestellt
 
 ## BUG FIXES
 - `IFS-4526`: [isy-task] Logeintrag IsyTaskAspect korrigiert

--- a/isy-batchrahmen/CHANGELOG.md
+++ b/isy-batchrahmen/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 4.1.0
-### Bug Fixes
+## Features
+
+- `IFS-4748`: Alle deprecated Spring-Boot-Funktionen auf aktuelle Alternativen umgestellt
+
+## Bug Fixes
 - `IFS-4753`: Änderung der Konfigurationsreihenfolge.
   * BatchSecurityConfiguration wird nach Anwendung und BatchRahmen Konfiguration geladen.
   * Beans mit der `@ConditionalOnMissingBean(...)` Annotation können wie erwartet überschrieben werden.

--- a/isy-batchrahmen/src/main/java/de/bund/bva/isyfact/batchrahmen/config/BatchSecurityConfiguration.java
+++ b/isy-batchrahmen/src/main/java/de/bund/bva/isyfact/batchrahmen/config/BatchSecurityConfiguration.java
@@ -5,12 +5,11 @@ import java.util.List;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.security.oauth2.client.ClientsConfiguredCondition;
+import org.springframework.boot.autoconfigure.security.oauth2.client.ConditionalOnOAuth2ClientRegistrationProperties;
 import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
 import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientPropertiesMapper;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
@@ -40,7 +39,7 @@ import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepo
 @Configuration
 @EnableConfigurationProperties(OAuth2ClientProperties.class)
 @ConditionalOnClass({ClientRegistration.class, EnableWebSecurity.class})
-@Conditional(ClientsConfiguredCondition.class)
+@ConditionalOnOAuth2ClientRegistrationProperties
 public class BatchSecurityConfiguration {
 
     @Bean

--- a/isy-batchrahmen/src/main/java/de/bund/bva/isyfact/batchrahmen/config/BatchSecurityConfiguration.java
+++ b/isy-batchrahmen/src/main/java/de/bund/bva/isyfact/batchrahmen/config/BatchSecurityConfiguration.java
@@ -24,7 +24,7 @@ import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepo
  * !!! Workaround !!!
  * <p>
  * Since {@code WebApplicationType.NONE} is set in the BatchLauncher, the
- * {@link org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration}
+ * {@link org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration}
  * is not loaded due to the annotation
  * {@code @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)}.
  * <p>

--- a/isy-security/CHANGELOG.md
+++ b/isy-security/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `IFS-4785`: Hinzufügen einer Property für die Restlebensdauer gecachter OAuth2-Token
 - `IFS-4752`: Wiederherstellen der initialen Authentication nach Authentifizierung mit @Authenticate-Annotation
 - `IFS-4810`: Ausbau der Validierung des "aud"-Claims erstellter Tokens
+- `IFS-4748`: Alle deprecated Spring-Boot-Funktionen auf aktuelle Alternativen umgestellt
 
 ## Breaking Changes
 - `IFS-4812`: Verwendung sicherer Hashfunktion mit SHA-512 für Caching

--- a/isy-security/src/main/java/de/bund/bva/isyfact/security/autoconfigure/IsyOAuth2ClientAutoConfiguration.java
+++ b/isy-security/src/main/java/de/bund/bva/isyfact/security/autoconfigure/IsyOAuth2ClientAutoConfiguration.java
@@ -7,12 +7,11 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.security.oauth2.client.ClientsConfiguredCondition;
+import org.springframework.boot.autoconfigure.security.oauth2.client.ConditionalOnOAuth2ClientRegistrationProperties;
 import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.lang.Nullable;
@@ -113,7 +112,7 @@ public class IsyOAuth2ClientAutoConfiguration {
      * Beans defined in this class are only required if any ClientRegistrations are configured.
      */
     @Configuration
-    @Conditional(ClientsConfiguredCondition.class)
+    @ConditionalOnOAuth2ClientRegistrationProperties
     public static class ClientsConfiguredDependentBeans {
 
         /** Identifier for the AuthorizedClientManager created by isy-security. */

--- a/isy-security/src/test/java/de/bund/bva/isyfact/security/autoconfigure/IsySecurityAutoConfigurationTest.java
+++ b/isy-security/src/test/java/de/bund/bva/isyfact/security/autoconfigure/IsySecurityAutoConfigurationTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
-import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;

--- a/isy-security/src/test/java/de/bund/bva/isyfact/security/oauth2/client/AuthentifizierungsmanagerTest.java
+++ b/isy-security/src/test/java/de/bund/bva/isyfact/security/oauth2/client/AuthentifizierungsmanagerTest.java
@@ -12,7 +12,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authentication.TestingAuthenticationToken;
@@ -25,6 +24,7 @@ import org.springframework.security.oauth2.server.resource.authentication.Abstra
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import de.bund.bva.isyfact.security.AbstractOidcProviderTest;
 import de.bund.bva.isyfact.security.autoconfigure.IsyOAuth2ClientAutoConfiguration;
@@ -36,6 +36,7 @@ import de.bund.bva.isyfact.security.oauth2.client.authentication.PasswordClientR
 import de.bund.bva.isyfact.security.oauth2.client.authentication.token.ClientCredentialsClientRegistrationAuthenticationToken;
 import de.bund.bva.isyfact.security.oauth2.client.authentication.token.ClientCredentialsRegistrationIdAuthenticationToken;
 import de.bund.bva.isyfact.security.oauth2.client.authentication.token.PasswordClientRegistrationAuthenticationToken;
+
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -64,13 +65,13 @@ import static org.mockito.Mockito.when;
 })
 public class AuthentifizierungsmanagerTest extends AbstractOidcProviderTest {
 
-    @MockBean
+    @MockitoBean
     private ClientCredentialsAuthorizedClientAuthenticationProvider clientCredentialsAuthorizedClientAuthenticationProvider;
 
-    @MockBean
+    @MockitoBean
     private PasswordClientRegistrationAuthenticationProvider passwordClientRegistrationAuthenticationProvider;
 
-    @MockBean
+    @MockitoBean
     private ClientCredentialsClientRegistrationAuthenticationProvider clientCredentialsClientRegistrationAuthenticationProvider;
 
     @Autowired

--- a/isy-security/src/test/java/de/bund/bva/isyfact/security/oauth2/client/AuthentifizierungsmanagerWithDisabledCacheTest.java
+++ b/isy-security/src/test/java/de/bund/bva/isyfact/security/oauth2/client/AuthentifizierungsmanagerWithDisabledCacheTest.java
@@ -10,11 +10,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import de.bund.bva.isyfact.security.AbstractOidcProviderTest;
 import de.bund.bva.isyfact.security.oauth2.client.authentication.ClientCredentialsClientRegistrationAuthenticationProvider;
@@ -28,7 +28,7 @@ import de.bund.bva.isyfact.security.oauth2.client.authentication.ClientCredentia
 })
 public class AuthentifizierungsmanagerWithDisabledCacheTest extends AbstractOidcProviderTest {
 
-    @MockBean
+    @MockitoBean
     private ClientCredentialsClientRegistrationAuthenticationProvider clientCredentialsProvider;
 
     @Autowired

--- a/isy-security/src/test/java/de/bund/bva/isyfact/security/oauth2/client/AuthentifizierungsmanagerWithoutClientsConfiguredTest.java
+++ b/isy-security/src/test/java/de/bund/bva/isyfact/security/oauth2/client/AuthentifizierungsmanagerWithoutClientsConfiguredTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -29,10 +29,10 @@ import de.bund.bva.isyfact.security.oauth2.client.authentication.token.PasswordC
 @SpringBootTest
 public class AuthentifizierungsmanagerWithoutClientsConfiguredTest extends AbstractOidcProviderTest {
 
-    @MockBean
+    @MockitoBean
     private ClientCredentialsClientRegistrationAuthenticationProvider clientCredentialsClientRegistrationAuthenticationProvider;
 
-    @MockBean
+    @MockitoBean
     private PasswordClientRegistrationAuthenticationProvider passwordClientRegistrationAuthenticationProvider;
 
     @Autowired

--- a/isy-security/src/test/java/de/bund/bva/isyfact/security/oauth2/client/annotation/MethodAuthenticationTest.java
+++ b/isy-security/src/test/java/de/bund/bva/isyfact/security/oauth2/client/annotation/MethodAuthenticationTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -41,7 +41,7 @@ public class MethodAuthenticationTest {
 
     private static final String CLIENT_ID = "my-auth-client";
 
-    @MockBean
+    @MockitoBean
     private Authentifizierungsmanager authentifizierungsmanager;
 
     @Autowired


### PR DESCRIPTION
- change deprecated @MockBean to @MockitoBean
- change deprecated @Conditional(ClientsConfiguredCondition.class) to @ConditionalOnOAuth2ClientRegistrationProperties
- use new import for OAuth2ClientAutoConfiguration because the old one is deprecated
